### PR TITLE
Deploy documentation to Github pages

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,8 +9,8 @@ jobs:
         working-directory: docs/html
         run: |
           git init
-          git config user.name "guardsquare-ci"
-          git config user.email "guardsquare-ci@guardsquare.com"
+          git config user.name "Eric Salemi"
+          git config user.email "eric.salemi@guardsquare.com"
           git add .
           git commit -m "Deploy documentation to Github pages"
-          git push --force --quiet https://${{secrets.PROGUARD_GITHUB_TOKEN}}@github.com/Guardsquare/proguard-core master:gh-pages
+          git push --force --quiet https://${{secrets.ERIC_SALEMI_TOKEN}}@github.com/Guardsquare/proguard-core master:gh-pages

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,4 +13,4 @@ jobs:
           git config user.email "eric.salemi@guardsquare.com"
           git add .
           git commit -m "Deploy documentation to Github pages"
-          git push --force --quiet https://${{secrets.ERIC_SALEMI_TOKEN}}@github.com/Guardsquare/proguard-core master:gh-pages
+          git push --force --quiet https://${{secrets.PROGUARD_GITHUB_TOKEN}}@github.com/Guardsquare/proguard-core master:gh-pages

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,16 @@
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - run: docker run --user `id -u` --volume $GITHUB_WORKSPACE/docs:/docs squidfunk/mkdocs-material:5.2.2 build
+      - name: Publish to Github pages
+        working-directory: docs/html
+        run: |
+          git init
+          git config user.name "guardsquare-ci"
+          git config user.email "gitsquare-ci@guardsquare.com"
+          git add .
+          git commit -m "Deploy documentation to Github pages"
+          git push --force --quiet https://${{secrets.PROGUARD_GITHUB_TOKEN}}@github.com/Guardsquare/proguard-core master:gh-pages

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,7 +10,7 @@ jobs:
         run: |
           git init
           git config user.name "guardsquare-ci"
-          git config user.email "gitsquare-ci@guardsquare.com"
+          git config user.email "guardsquare-ci@guardsquare.com"
           git add .
           git commit -m "Deploy documentation to Github pages"
           git push --force --quiet https://${{secrets.PROGUARD_GITHUB_TOKEN}}@github.com/Guardsquare/proguard-core master:gh-pages

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,8 +9,8 @@ jobs:
         working-directory: docs/html
         run: |
           git init
-          git config user.name "Eric Salemi"
-          git config user.email "eric.salemi@guardsquare.com"
+          git config user.name "gitsquare-ci"
+          git config user.email "gitsquare-ci@guardsquare.com"
           git add .
           git commit -m "Deploy documentation to Github pages"
           git push --force --quiet https://${{secrets.PROGUARD_GITHUB_TOKEN}}@github.com/Guardsquare/proguard-core master:gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build
 .gradle
 *.iml
 /docs/api/
+/docs/html/
+/venv/

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -10,14 +10,11 @@ copyright:        Copyright &copy; 2002-2020 Guardsquare NV
 # Options
 ###################################################################
 theme:
-  name:       null
-  custom_dir: ../../../mkdocs/material
-  logo:       img/core.png
-  favicon:    img/guardsquare.png
-  language:   en
-  palette:    blue
-  font:
-  feature:
+  name: material
+  logo: img/core.png
+  favicon: img/guardsquare.png
+  language: en
+  palette: blue
 
 docs_dir: md
 site_dir: html
@@ -36,12 +33,12 @@ extra:
   #  text: 'Droid Sans'
   #  code: 'Ubuntu Mono'
   social:
-  - type: 'twitter'
-    link: 'https://twitter.com/guardsquare'
-  - type: 'linkedin'
-    link: 'https://www.linkedin.com/company/guardsquare-nv'
-  - type: 'facebook'
-    link: 'https://www.facebook.com/guardsquare'
+  - icon: fontawesome/brands/twitter
+    link: https://twitter.com/guardsquare
+  - icon: fontawesome/brands/linkedin
+    link: https://www.linkedin.com/company/guardsquare-nv
+  - icon: fontawesome/brands/facebook
+    link: https://www.facebook.com/guardsquare
   #feature:
   #  tabs: true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs==1.1.2
+mkdocs-material==5.2.2


### PR DESCRIPTION
New Github workflow to automatically deploy documentation to github pages.

Initially on every push. Later only on release tag push.