### PR TITLE
Fix api links

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,7 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: docker run --user `id -u` --volume $GITHUB_WORKSPACE/docs:/docs squidfunk/mkdocs-material:5.2.2 build
+      - uses: actions/setup-java@v1
+          with:
+            java-version: 8
+      - uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: buildDocumentation
       - name: Publish to Github pages
         if: github.event_name == 'push'
         working-directory: docs/html

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: docker run --user `id -u` --volume $GITHUB_WORKSPACE/docs:/docs squidfunk/mkdocs-material:5.2.2 build
       - name: Publish to Github pages
+        if: github.event_name == 'push'
         working-directory: docs/html
         run: |
           git init

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - run: docker run --user `id -u` --volume $GITHUB_WORKSPACE/docs:/docs squidfunk/mkdocs-material:5.2.2 build
       - name: Publish to Github pages
         working-directory: docs/html

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,3 +1,4 @@
+name: Documentation
 on:
   pull_request:
     branches:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 build
 .gradle
 *.iml
-/docs/api/
+/docs/md/api/
 /docs/html/
 /venv/

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,11 @@ javadoc {
     options.addStringOption('Xdoclint:none', '-quiet')
 }
 
+task buildDocumentation(type: Exec) {
+    executable 'sh'
+    args '-c', "docker run --volume $rootDir/docs:/docs --rm squidfunk/mkdocs-material:5.2.2 build"
+}
+
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}"
     compile "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlinVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ javadoc {
     title          = 'ProGuardCORE'
     source         = sourceSets.main.allJava
     classpath      = configurations.compile
-    destinationDir = file('docs/api')
+    destinationDir = file('docs/md/api')
     options.addStringOption('Xdoclint:none', '-quiet')
 }
 

--- a/docs/md/building.md
+++ b/docs/md/building.md
@@ -20,4 +20,4 @@ You can also build the complete API documentation with
 
     gradle javadoc
 
-You can then find the [API documentation](../api/index.html) in `docs/api`.
+You can then find the [API documentation](api/index.html) in `docs/api`.

--- a/docs/md/index.md
+++ b/docs/md/index.md
@@ -68,4 +68,4 @@ can execute such commands by applying the visitors to the data classes.
 ## API
 
 You can find the complete API in the [ProGuardCORE
-javadoc](../api/index.html).
+javadoc](api/index.html).


### PR DESCRIPTION
Fix API links in generated Github pages:

- Moved javadoc artifacts in `docs/md/api`
- Let mkdocs include javadoc in the generated site

