### PR TITLE
Add distribution files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,11 @@ distributions {
     }
 }
 
+distTar {
+    compression = Compression.GZIP
+    archiveExtension.set('tar.gz')
+}
+
 publishing {
     publications {
         create('proguardCore', MavenPublication) {

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ distributions {
             }
             from(rootDir) {
                 include 'examples/'
+                include 'LICENSE'
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'distribution'
     id 'java'
     id 'maven-publish'
     id 'signing'
@@ -63,6 +64,19 @@ dependencies {
 java {
     withSourcesJar()
     withJavadocJar()
+}
+
+distributions {
+    main {
+        contents {
+            into('docs') {
+                from(buildDocumentation)
+            }
+            from(rootDir) {
+                include 'examples/'
+            }
+        }
+    }
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ distributions {
     main {
         contents {
             into('docs') {
-                from(buildDocumentation)
+                from('docs/md')
             }
             from(rootDir) {
                 include 'examples/'

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ java {
 
 distributions {
     main {
+        distributionBaseName.set('proguard-core')
         contents {
             into('docs') {
                 from('docs/md') {

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,8 @@ distributions {
         contents {
             into('docs') {
                 from('docs/md') {
-                    include '*.md'
+                    includeEmptyDirs = false
+                    include '**/*.md'
                 }
             }
             from(rootDir) {

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,9 @@ distributions {
     main {
         contents {
             into('docs') {
-                from('docs/md')
+                from('docs/md') {
+                    include '*.md'
+                }
             }
             from(rootDir) {
                 include 'examples/'

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -23,6 +23,5 @@ sourceSets.main {
 }
 
 dependencies {
-    //compile project('com.guardsquare:proguard-core:7.0.0')
-    compile files("../../core/build/classes/java/main")
+    compile 'com.guardsquare:proguard-core:7.0.0'
 }


### PR DESCRIPTION
Added basic distribution files with the `distributions` Gradle plugin.

Added static HTML content as generated for Github pages.

Also fixed examples dependencies which builds fine with composite build:

```shell
proguard-core/examples > gradle --include-build .. clean build
```

The new `settings.gradle` is necessary for the nested Gradle project to work with more recent version of Gradle. We could also add the Gradle wrapper to the examples. The `..` included build refers here to the `proguard-core` project itself which is one level up.

@EricLafortune @dzan  What else would you add in the dist files?