### PR TITLE
Replace JCenter badge with Maven Central badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,6 @@
     <img src="https://github.com/Guardsquare/proguard-core/workflows/Continuous%20Integration/badge.svg">
   </a>
   
-  <!-- jcenter -->
-  <a href='https://bintray.com/guardsquare/proguard/com.guardsquare%3Aproguard-core/_latestVersion'>
-    <img alt="jcenter" src="https://img.shields.io/bintray/v/guardsquare/proguard/com.guardsquare:proguard-core?label=jcenter">
-  </a>
-  
   <!-- Github version -->
   <!--
   <a href="releases">
@@ -30,11 +25,9 @@
   -->
 
   <!-- Maven -->
-  <!--
   <a href="https://search.maven.org/search?q=g:com.guardsquare">
     <img src="https://img.shields.io/maven-central/v/com.guardsquare/proguard-core">
   </a>
-  -->
 
   <!-- License -->
   <a href="LICENSE">


### PR DESCRIPTION
JCenter badge no longer shows the latest version.

Let's update the badge to show Maven Central instead.

