### PR TITLE
Change == to equals in KotlinMetadataAnnotationTest

### DIFF
--- a/src/test/kotlin/proguard/classfile/kotlin/KotlinMetadataAnnotationTest.kt
+++ b/src/test/kotlin/proguard/classfile/kotlin/KotlinMetadataAnnotationTest.kt
@@ -244,7 +244,7 @@ class KotlinMetadataAnnotationTest : FreeSpec({
         }
 
         "Then it should be equal to itself" {
-            (annotation1 == annotation1) shouldBe true
+            (annotation1.equals(annotation1)) shouldBe true
         }
     }
 


### PR DESCRIPTION
The test remains the same, but Sonar analysis considers using `==` here an issue