### PR TITLE
Combine build and sonar jobs in workflow

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -20,10 +20,10 @@ jobs:
         uses: eskatos/gradle-command-action@v1
         with:
           arguments: assemble    
-      - name: Test
+      - name: Check
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: check     
+          arguments: check
       - name: Sonar
         run: gradle -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN -Dsonar.organization=guardsquare -Dsonar.projectKey=Guardsquare_proguard-core sonarqube
         env:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -12,11 +12,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - name: Setup Java  
+        uses: actions/setup-java@v1
         with:
           java-version: 11
       - name: Build    
-      - uses: eskatos/gradle-command-action@v1
+        uses: eskatos/gradle-command-action@v1
         with:
           arguments: build
       - name: Sonar

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -20,10 +20,10 @@ jobs:
         uses: eskatos/gradle-command-action@v1
         with:
           arguments: assemble
-      - name: Check
+      - name: Build
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: check
+          arguments: build
       - name: Sonar
         run: gradle -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN -Dsonar.organization=guardsquare -Dsonar.projectKey=Guardsquare_proguard-core sonarqube
         env:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -12,14 +12,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Java  
+      - name: Setup Java
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Assemble    
+      - name: Assemble
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: assemble    
+          arguments: assemble
       - name: Check
         uses: eskatos/gradle-command-action@v1
         with:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -19,21 +19,13 @@ jobs:
       - name: Assemble    
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: assemble
-      - name: Check
-        uses: eskatos/gradle-command-action@v1
-        with:
-          arguments: check      
+          arguments: assemble    
       - name: Test
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: test     
+          arguments: check     
       - name: Sonar
-        uses: eskatos/gradle-command-action@v1
-        with:
-          arguments: sonarqube
+        run: gradle -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN -Dsonar.organization=guardsquare -Dsonar.projectKey=Guardsquare_proguard-core sonarqube
         env:
-          ORG_GRADLE_PROJECT_sonar.host.url: https://sonarcloud.io
-          ORG_GRADLE_PROJECT_sonar.organization: guardsquare
-          ORG_GRADLE_PROJECT_sonar.projectKey: Guardsquare_proguard-core
-          ORG_GRADLE_PROJECT_sonar.login: ${{ secrets.PROGUARD_SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PROGUARD_GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.PROGUARD_SONAR_TOKEN }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -10,22 +10,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 8
-      - uses: eskatos/gradle-command-action@v1
-        with:
-          arguments: build
-  sonar:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
           java-version: 11
+      - name: Build    
+      - uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: build
       - name: Sonar
-        run: gradle -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN -Dsonar.organization=guardsquare -Dsonar.projectKey=Guardsquare_proguard-core sonarqube
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: gradle -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN -Dsonar.organization=guardsquare -Dsonar.projectKey=Guardsquare_proguard-core sonarqube
         env:
           GITHUB_TOKEN: ${{ secrets.PROGUARD_GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.PROGUARD_SONAR_TOKEN }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Sonar
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: sonarqube -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN -Dsonar.organization=guardsquare -Dsonar.projectKey=Guardsquare_proguard-core
+          arguments: sonarqube
         env:
-          GITHUB_TOKEN: ${{ secrets.PROGUARD_GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.PROGUARD_SONAR_TOKEN }}
+          ORG_GRADLE_PROJECT_sonar.host.url: https://sonarcloud.io
+          ORG_GRADLE_PROJECT_sonar.organization: guardsquare
+          ORG_GRADLE_PROJECT_sonar.projectKey: Guardsquare_proguard-core
+          ORG_GRADLE_PROJECT_sonar.login: ${{ secrets.PROGUARD_SONAR_TOKEN }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -16,14 +16,22 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Build    
+      - name: Assemble    
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: build
+          arguments: assemble
+      - name: Check
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: check      
+      - name: Test
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: test     
       - name: Sonar
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: gradle -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN -Dsonar.organization=guardsquare -Dsonar.projectKey=Guardsquare_proguard-core sonarqube
+          arguments: sonarqube -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN -Dsonar.organization=guardsquare -Dsonar.projectKey=Guardsquare_proguard-core
         env:
           GITHUB_TOKEN: ${{ secrets.PROGUARD_GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.PROGUARD_SONAR_TOKEN }}


### PR DESCRIPTION
This PR combines the build & Sonar jobs into one single job so that the test coverage report is available for Sonar Cloud.