### PR TITLE
Guardsquare/proguard#194: Incorrect handling of Record.Signature attribute

### DIFF
--- a/src/main/java/proguard/classfile/util/ClassReferenceInitializer.java
+++ b/src/main/java/proguard/classfile/util/ClassReferenceInitializer.java
@@ -544,6 +544,22 @@ implements   ClassVisitor,
         }
     }
 
+    @Override
+    public void visitSignatureAttribute(Clazz clazz, RecordComponentInfo recordComponentInfo, SignatureAttribute signatureAttribute)
+    {
+        try
+        {
+            signatureAttribute.referencedClasses =
+                findReferencedClasses(clazz,
+                                      signatureAttribute.getSignature(clazz));
+        }
+        catch (Exception corruptSignature)
+        {
+            // #2468: delete corrupt signature attributes, since they
+            // cannot be otherwise worked around.
+            recordComponentInfo.attributesAccept(clazz, new NamedAttributeDeleter(Attribute.SIGNATURE));
+        }
+    }
 
     @Override
     public void visitSignatureAttribute(Clazz clazz, SignatureAttribute signatureAttribute)


### PR DESCRIPTION
* Fixes class-level Signature attribute being lost
* Fixes part of Record attribute remaining unobfuscated

See linked issue for further information.