### PR TITLE
Add experimental transform command

### DIFF
--- a/tools/src/main/kotlin/com.guardsquare.proguard.tools/Main.kt
+++ b/tools/src/main/kotlin/com.guardsquare.proguard.tools/Main.kt
@@ -24,6 +24,7 @@ import proguard.classfile.visitor.MemberVisitor
 import proguard.io.DexClassReader
 import proguard.io.NameFilteredDataEntryReader
 import proguard.io.util.IOUtil
+import proguard.io.util.IOUtil.writeJar
 import java.io.File
 
 @ExperimentalCli
@@ -160,7 +161,7 @@ fun main(args: Array<String>) {
                 System.err.println("$file exists, use --force to overwrite")
                 return
             }
-            IOUtil.writeJar(programClassPool, file.absolutePath)
+            writeJar(programClassPool, file.absolutePath)
         }
     }
 
@@ -173,11 +174,11 @@ fun main(args: Array<String>) {
         }
     }
 
-    parser.subcommands(Dex2JarCmd(), Jar2DexCmd(), ListCmd(), PrintCmd())
+    parser.subcommands(Dex2JarCmd(), Jar2DexCmd(), ListCmd(), PrintCmd(), TransformCmd())
     parser.parse(args)
 }
 
-private fun read(
+fun read(
     filename: String,
     classNameFilter: String,
     isLibrary: Boolean

--- a/tools/src/main/kotlin/com.guardsquare.proguard.tools/TransformCmd.kt
+++ b/tools/src/main/kotlin/com.guardsquare.proguard.tools/TransformCmd.kt
@@ -60,7 +60,8 @@ class TransformCmd : Subcommand("transform", "Apply transformations to input") {
                         this.getField("programClassPool").type == ClassPool::class.java
                     ) {
                         this.getField("programClassPool").set(it, programClassPool)
-                    } else if (this.fields.count { it.name == "libraryClassPool" } > 0 &&
+                    }
+                    if (this.fields.count { it.name == "libraryClassPool" } > 0 &&
                         this.getField("libraryClassPool").type == ClassPool::class.java
                     ) {
                         this.getField("libraryClassPool").set(it, libraryClassPool)

--- a/tools/src/main/kotlin/com.guardsquare.proguard.tools/TransformCmd.kt
+++ b/tools/src/main/kotlin/com.guardsquare.proguard.tools/TransformCmd.kt
@@ -5,6 +5,7 @@ import kotlinx.cli.ExperimentalCli
 import kotlinx.cli.Subcommand
 import kotlinx.cli.default
 import kotlinx.cli.required
+import proguard.classfile.AccessConstants.PUBLIC
 import proguard.classfile.ClassPool
 import proguard.classfile.LibraryClass
 import proguard.classfile.ProgramClass
@@ -51,6 +52,7 @@ class TransformCmd : Subcommand("transform", "Apply transformations to input") {
             .classes()
             .asSequence()
             .filter { it.extendsOrImplements(internalClassName(ClassVisitor::class.java.name)) }
+            .filter { it.accessFlags and PUBLIC == PUBLIC }
             .map { classLoader.loadClass(externalClassName(it.name)) as Class<ClassVisitor> }
             .map { it.getDeclaredConstructor().newInstance() }
             .onEach {

--- a/tools/src/main/kotlin/com.guardsquare.proguard.tools/TransformCmd.kt
+++ b/tools/src/main/kotlin/com.guardsquare.proguard.tools/TransformCmd.kt
@@ -32,6 +32,7 @@ class TransformCmd : Subcommand("transform", "Apply transformations to input") {
     var output by option(ArgType.String, description = "Output file name", shortName = "o", fullName = "output")
     var transformer by option(ArgType.String, description = "Classes containing ClassVisitor implementations", shortName = "t", fullName = "transformer").required()
     var printClasses by option(ArgType.Boolean, description = "Print classes after applying ClassVisitors").default(false)
+    var classNameFilter by option(ArgType.String, description = "Class name filter", shortName = "cf", fullName = "classNameFilter").default("**")
 
     private val programClassPool: ClassPool by lazy { read(input, "**", false) }
     private val transformersPool: ClassPool by lazy { read(transformer, "**", false) }
@@ -79,7 +80,7 @@ class TransformCmd : Subcommand("transform", "Apply transformations to input") {
             .toList()
             .toTypedArray()
 
-        programClassPool.classesAccept(MultiClassVisitor(*classVisitors))
+        programClassPool.classesAccept(classNameFilter, MultiClassVisitor(*classVisitors))
 
         if (printClasses) programClassPool.classesAccept(ClassPrinter())
 

--- a/tools/src/main/kotlin/com.guardsquare.proguard.tools/TransformCmd.kt
+++ b/tools/src/main/kotlin/com.guardsquare.proguard.tools/TransformCmd.kt
@@ -1,0 +1,122 @@
+package com.guardsquare.proguard.tools
+
+import kotlinx.cli.ArgType
+import kotlinx.cli.ExperimentalCli
+import kotlinx.cli.Subcommand
+import kotlinx.cli.required
+import proguard.classfile.ClassPool
+import proguard.classfile.LibraryClass
+import proguard.classfile.ProgramClass
+import proguard.classfile.io.LibraryClassReader
+import proguard.classfile.io.ProgramClassReader
+import proguard.classfile.util.ClassPoolClassLoader
+import proguard.classfile.util.ClassReferenceInitializer
+import proguard.classfile.util.ClassSuperHierarchyInitializer
+import proguard.classfile.util.ClassUtil.externalClassName
+import proguard.classfile.util.ClassUtil.internalClassName
+import proguard.classfile.util.WarningPrinter
+import proguard.classfile.visitor.ClassVisitor
+import proguard.classfile.visitor.MultiClassVisitor
+import proguard.io.util.IOUtil.writeJar
+import java.io.DataInputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.PrintWriter
+
+@OptIn(ExperimentalCli::class)
+class TransformCmd : Subcommand("transform", "Apply transformations to input") {
+    var input by argument(ArgType.String, description = "Input file name")
+    var output by option(ArgType.String, description = "Output file name", shortName = "o", fullName = "output")
+    var transformer by option(ArgType.String, description = "classes containing ClassVisitor implementations", shortName = "t", fullName = "transformer").required()
+
+    private val programClassPool: ClassPool by lazy { read(input, "**", false) }
+    private val transformersPool: ClassPool by lazy { read(transformer, "**", false) }
+
+    override fun execute() {
+        val transformersLibraryClassPool = ClassPool()
+        // Add ClassVisitor to the library class pool, so that Clazz.extendsOrImplements can be used.
+        transformersLibraryClassPool.addLibraryClass(ClassVisitor::class.java)
+
+        initialize(transformersPool, transformersLibraryClassPool)
+        initialize(programClassPool, ClassPool()) // TODO: libraryClassPool
+
+        val classLoader = ClassPoolClassLoader(transformersPool)
+
+        // Load all the ClassVisitor classes and create instances
+        val classVisitors = transformersPool
+            .classes()
+            .filter { it.extendsOrImplements(internalClassName(ClassVisitor::class.java.name)) }
+            .map { classLoader.loadClass(externalClassName(it.name)) as Class<ClassVisitor> }
+            .map { it.getDeclaredConstructor().newInstance() }
+            .map { MultiClassVisitor({ clazz -> println("Transforming ${clazz.name}") }, it) }
+            .toTypedArray()
+
+        programClassPool.classesAccept(MultiClassVisitor(*classVisitors))
+
+        writeJar(programClassPool, output ?: input)
+    }
+
+    private fun initialize(programClassPool: ClassPool, libraryClassPool: ClassPool) {
+        // TODO: put this util in ProGuardCORE
+        // TODO: hide warnings for now
+        val printWriter = PrintWriter(object : OutputStream() {
+            override fun write(b: Int) {
+            }
+        })
+        val warningPrinter = WarningPrinter(printWriter)
+
+        // Initialize the class hierarchies.
+        libraryClassPool.classesAccept(
+            ClassSuperHierarchyInitializer(
+                programClassPool,
+                libraryClassPool,
+                null,
+                null
+            )
+        )
+        programClassPool.classesAccept(
+            ClassSuperHierarchyInitializer(
+                programClassPool,
+                libraryClassPool,
+                warningPrinter,
+                warningPrinter
+            )
+        )
+
+        // Initialize the other references from the program classes.
+        programClassPool.classesAccept(
+            ClassReferenceInitializer(
+                programClassPool,
+                libraryClassPool,
+                warningPrinter,
+                warningPrinter,
+                warningPrinter,
+                null
+            )
+        )
+
+        // Flush the warnings.
+        printWriter.flush()
+    }
+
+    private fun ClassPool.addClass(vararg classes: Class<*>) {
+        // TODO: put this util in ProGuardCORE
+        for (clazz in classes) {
+            val `is` = this::class.java.classLoader.getResourceAsStream("${internalClassName(clazz.name)}.class") as InputStream
+            val classReader = ProgramClassReader(DataInputStream(`is`))
+            val programClass = ProgramClass()
+            programClass.accept(classReader)
+            addClass(programClass)
+        }
+    }
+    private fun ClassPool.addLibraryClass(vararg classes: Class<*>) {
+        // TODO: put this util in ProGuardCORE
+        for (clazz in classes) {
+            val `is` = this::class.java.classLoader.getResourceAsStream("${internalClassName(clazz.name)}.class") as InputStream
+            val classReader = LibraryClassReader(DataInputStream(`is`), false, false)
+            val libraryClass = LibraryClass()
+            libraryClass.accept(classReader)
+            addClass(libraryClass)
+        }
+    }
+}

--- a/tools/src/main/kotlin/com.guardsquare.proguard.tools/TransformCmd.kt
+++ b/tools/src/main/kotlin/com.guardsquare.proguard.tools/TransformCmd.kt
@@ -27,7 +27,7 @@ import java.io.OutputStream
 import java.io.PrintWriter
 
 @OptIn(ExperimentalCli::class)
-class TransformCmd : Subcommand("transform", "Apply transformations to input") {
+class TransformCmd : Subcommand("transform", "Apply transformations to input (experimental)") {
     var input by argument(ArgType.String, description = "Input file name")
     var output by option(ArgType.String, description = "Output file name", shortName = "o", fullName = "output")
     var transformer by option(ArgType.String, description = "Classes containing ClassVisitor implementations", shortName = "t", fullName = "transformer").required()


### PR DESCRIPTION
Adds a `transform` command to the command line tools:

```
$ proguard-core-tools transform input.jar --transformer transformer.jar --output output.jar
```

`transformer.jar` should contain classes that implement `ClassVisitor`. These class visitors are instantiated and applied to the `input.jar`; the result is written to the `output.jar`

# Example transform implementation

```java
public class MyTransformer implements ClassVisitor {
    @Override
    public void visitAnyClass(Clazz clazz) { }

    @Override
    public void visitProgramClass(ProgramClass programClass) {
        InstructionSequenceBuilder ____ =
            new InstructionSequenceBuilder();

        Instruction[][] replacements =
            {
                ____.ldc("Hello world!").__(),

                ____.ldc("Hallo wereld!").__()
            };

        Constant[] constants = ____.constants();

        BranchTargetFinder branchTargetFinder  = new BranchTargetFinder();
        CodeAttributeEditor codeAttributeEditor = new CodeAttributeEditor();

        programClass.methodsAccept(
            new AllAttributeVisitor(
            new PeepholeEditor(branchTargetFinder, codeAttributeEditor,
            new InstructionSequenceReplacer(constants,
                                            replacements[0],
                                            constants,
                                            replacements[1],
                                            branchTargetFinder,
                                            codeAttributeEditor))));
    }
}
```

Applied to this:

```
public class Main {
    public static void main(String[] args) {
        System.out.println("Hello world!");
    }
}
```

Results in:

```
public class Main {
    public static void main(String[] args) {
        System.out.println("Hallo wereld!");
    }
}
```

[transformerTest.zip](https://github.com/Guardsquare/proguard-core/files/9254700/transformerTest.zip)


