### PR TITLE
Update maximum Java version to 19-ea

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -24,16 +24,16 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}"
     testFixturesImplementation "org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}"
     testFixturesImplementation 'com.github.tschuchortdev:kotlin-compile-testing:1.4.9'
-    testFixturesImplementation 'io.kotest:kotest-runner-junit5-jvm:5.3.1' // for kotest framework
-    testImplementation 'io.kotest:kotest-runner-junit5-jvm:5.3.1' // for kotest framework
-    testImplementation 'io.kotest:kotest-assertions-core-jvm:5.3.1' // for kotest core jvm assertions
+    testFixturesImplementation 'io.kotest:kotest-runner-junit5-jvm:5.4.1' // for kotest framework
+    testImplementation 'io.kotest:kotest-runner-junit5-jvm:5.4.1' // for kotest framework
+    testImplementation 'io.kotest:kotest-assertions-core-jvm:5.4.1' // for kotest core jvm assertions
     testFixturesImplementation 'io.kotest:kotest-assertions-core-jvm:5.3.1' // for kotest core jvm assertions
 
-    testImplementation 'io.kotest:kotest-property-jvm:5.3.1' // for kotest property test
-    testImplementation 'io.kotest:kotest-framework-datatest:5.3.1'
-    testImplementation "io.mockk:mockk:1.12.4" // for mocking
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1' // for junit framework
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1' // for junit framework
+    testImplementation 'io.kotest:kotest-property-jvm:5.4.1' // for kotest property test
+    testImplementation 'io.kotest:kotest-framework-datatest:5.4.1'
+    testImplementation 'io.mockk:mockk:1.12.5' // for mocking
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0' // for junit framework
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0' // for junit framework
 
     // For assembling ProGuard assembler snippets
     testFixturesImplementation ('com.github.Guardsquare:proguard-assembler:master-SNAPSHOT') {
@@ -63,6 +63,10 @@ task testAllJavaVersions() { testAllTask ->
 
     javaVersionsForTest.each {version ->
         task("testJava$version", type: Test) {
+
+            // The version of bytebuddy used by mockk only supports Java 19 experimentally so far
+            if (version == 19) systemProperty 'net.bytebuddy.experimental', true
+
             useJUnitPlatform()
             ignoreFailures = true
 

--- a/base/src/main/java/proguard/classfile/JavaVersionConstants.java
+++ b/base/src/main/java/proguard/classfile/JavaVersionConstants.java
@@ -50,4 +50,5 @@ public class JavaVersionConstants
     public static final String CLASS_VERSION_16        = "16";
     public static final String CLASS_VERSION_17        = "17";
     public static final String CLASS_VERSION_18        = "18";
+    public static final String CLASS_VERSION_19        = "19";
 }

--- a/base/src/main/java/proguard/classfile/VersionConstants.java
+++ b/base/src/main/java/proguard/classfile/VersionConstants.java
@@ -61,7 +61,10 @@ public class VersionConstants
     public static final int CLASS_VERSION_17_MAJOR  = 61;
     public static final int CLASS_VERSION_17_MINOR  = 0;
     public static final int CLASS_VERSION_18_MAJOR  = 62;
-    public static final int CLASS_VERSION_18_MINOR  = 65535;
+    public static final int CLASS_VERSION_18_MINOR  = 0;
+    public static final int CLASS_VERSION_19_MAJOR  = 63;
+    public static final int CLASS_VERSION_19_MINOR  = 65535;
+
 
     public static final int CLASS_VERSION_1_0 = (CLASS_VERSION_1_0_MAJOR << 16) | CLASS_VERSION_1_0_MINOR;
     public static final int CLASS_VERSION_1_2 = (CLASS_VERSION_1_2_MAJOR << 16) | CLASS_VERSION_1_2_MINOR;
@@ -81,6 +84,7 @@ public class VersionConstants
     public static final int CLASS_VERSION_16  = (CLASS_VERSION_16_MAJOR  << 16) | CLASS_VERSION_16_MINOR;
     public static final int CLASS_VERSION_17  = (CLASS_VERSION_17_MAJOR  << 16) | CLASS_VERSION_17_MINOR;
     public static final int CLASS_VERSION_18  = (CLASS_VERSION_18_MAJOR  << 16) | CLASS_VERSION_18_MINOR;
+    public static final int CLASS_VERSION_19  = (CLASS_VERSION_19_MAJOR  << 16) | CLASS_VERSION_19_MINOR;
 
-    public static final int MAX_SUPPORTED_VERSION = CLASS_VERSION_18;
+    public static final int MAX_SUPPORTED_VERSION = CLASS_VERSION_19;
 }

--- a/base/src/main/java/proguard/classfile/util/ClassUtil.java
+++ b/base/src/main/java/proguard/classfile/util/ClassUtil.java
@@ -112,6 +112,7 @@ public class ClassUtil
             externalClassVersion.equals(JavaVersionConstants.CLASS_VERSION_16)  ? VersionConstants.CLASS_VERSION_16  :
             externalClassVersion.equals(JavaVersionConstants.CLASS_VERSION_17)  ? VersionConstants.CLASS_VERSION_17  :
             externalClassVersion.equals(JavaVersionConstants.CLASS_VERSION_18)  ? VersionConstants.CLASS_VERSION_18  :
+            externalClassVersion.equals(JavaVersionConstants.CLASS_VERSION_19)  ? VersionConstants.CLASS_VERSION_19  :
                                                                                   0;
     }
 
@@ -143,6 +144,7 @@ public class ClassUtil
             case VersionConstants.CLASS_VERSION_16:  return JavaVersionConstants.CLASS_VERSION_16;
             case VersionConstants.CLASS_VERSION_17:  return JavaVersionConstants.CLASS_VERSION_17;
             case VersionConstants.CLASS_VERSION_18:  return JavaVersionConstants.CLASS_VERSION_18;
+            case VersionConstants.CLASS_VERSION_19:  return JavaVersionConstants.CLASS_VERSION_19;
             default:                                 return null;
         }
     }

--- a/base/src/test/kotlin/proguard/classfile/Java19PatternSwitchTest.kt
+++ b/base/src/test/kotlin/proguard/classfile/Java19PatternSwitchTest.kt
@@ -15,10 +15,14 @@ import proguard.testutils.RequiresJavaVersion
 import proguard.testutils.currentJavaVersion
 
 /**
- * Test the pattern matching switch in Java 18.
+ * Test the pattern matching switch in Java 19.
+ * The preview in Java 19 changed the guard syntax from `&&` to `when`.
  */
-@RequiresJavaVersion(18, 18)
-class JavaPatternSwitchTest : FreeSpec({
+@RequiresJavaVersion(19, 19)
+class Java19PatternSwitchTest : FreeSpec({
+
+    val javacArguments = if (currentJavaVersion in 19..19)
+        listOf("--enable-preview", "--release", currentJavaVersion.toString()) else emptyList()
 
     "Test PatternSwitch" - {
         "Instance of" - {
@@ -42,8 +46,7 @@ class JavaPatternSwitchTest : FreeSpec({
                     }
                     """.trimIndent()
                 ),
-                javacArguments = if (currentJavaVersion == 18)
-                    listOf("--enable-preview", "--release", "18") else emptyList()
+                javacArguments = javacArguments
             )
 
             "$className class should be in program class pool" {
@@ -70,8 +73,7 @@ class JavaPatternSwitchTest : FreeSpec({
                     }
                     """.trimIndent()
                 ),
-                javacArguments = if (currentJavaVersion == 18)
-                    listOf("--enable-preview", "--release", "18") else emptyList()
+                javacArguments = javacArguments
             )
             "$className class should be in program class pool" {
                 programClassPool.getClass(className) shouldNotBe null
@@ -95,8 +97,7 @@ class JavaPatternSwitchTest : FreeSpec({
                     }
                     """.trimIndent()
                 ),
-                javacArguments = if (currentJavaVersion == 18)
-                    listOf("--enable-preview", "--release", "18") else emptyList()
+                javacArguments = javacArguments
             )
 
             "$className class should be in program class pool" {
@@ -113,15 +114,14 @@ class JavaPatternSwitchTest : FreeSpec({
                     public class $className {
                         public static void foo(Object o) {
                             double value = switch (o) {
-                                case String s && s.length() > 0 -> Double.parseDouble(s);
+                                case String s when s.length() > 0 -> Double.parseDouble(s);
                                 default -> -1d;
                             };
                         }
                     }
                     """.trimIndent()
                 ),
-                javacArguments = if (currentJavaVersion == 18)
-                    listOf("--enable-preview", "--release", "18") else emptyList()
+                javacArguments = javacArguments
             )
 
             "$className class should be in program class pool" {
@@ -138,15 +138,14 @@ class JavaPatternSwitchTest : FreeSpec({
                     public class $className {
                         public static void foo(Object o) {
                             double value = switch (o) {
-                                case String s && s.length() > 0 && !(s.contains("//") || s.contains("#")) -> Double.parseDouble(s);
+                                case String s when s.length() > 0 && !(s.contains("//") || s.contains("#")) -> Double.parseDouble(s);
                                 default -> -1d;
                             };
                         }
                     }
                     """.trimIndent()
                 ),
-                javacArguments = if (currentJavaVersion == 18)
-                    listOf("--enable-preview", "--release", "18") else emptyList()
+                javacArguments = javacArguments
             )
 
             "$className class should be in program class pool" {
@@ -176,8 +175,7 @@ class JavaPatternSwitchTest : FreeSpec({
                     }
                     """.trimIndent()
                 ),
-                javacArguments = if (currentJavaVersion == 18)
-                    listOf("--enable-preview", "--release", "18") else emptyList()
+                javacArguments = javacArguments
             )
 
             "$className class should be in program class pool" {
@@ -204,8 +202,7 @@ class JavaPatternSwitchTest : FreeSpec({
                     }
                     """.trimIndent()
                 ),
-                javacArguments = if (currentJavaVersion == 18)
-                    listOf("--enable-preview", "--release", "18") else emptyList()
+                javacArguments = javacArguments
             )
 
             "$className class should be in program class pool" {

--- a/docs/md/releasenotes.md
+++ b/docs/md/releasenotes.md
@@ -1,5 +1,9 @@
 ## Version 9.0.3
 
+### Java support
+
+- Update maximum supported Java class version to 63.65535 (Java 19 ea). (`PGD-247`)
+
 ### Improved
 
 - Add utility to produce dot-graphs for control flow automatons (`CfaUtil.toDot(cfa)`, example `VisualizeCfa`).


### PR DESCRIPTION
The tests can be run with Java 19 by changing the maximum test version in `build.gradle` to 19 and running `./gradlew testJava19`.

Java 19 is not yet released so cannot be automatically installed by the Gradle toolchain, it should be manually installed first.