### PR TITLE
Improve InstructionOffsetValue performance

### DIFF
--- a/base/src/main/java/proguard/evaluation/value/InstructionOffsetValue.java
+++ b/base/src/main/java/proguard/evaluation/value/InstructionOffsetValue.java
@@ -45,7 +45,7 @@ public class InstructionOffsetValue extends Category1Value
 
 
     private final int[] values;
-    private final Set<Integer> valuesMap = new HashSet<>();
+    private Set<Integer> valuesMap;
 
 
     /**
@@ -53,8 +53,7 @@ public class InstructionOffsetValue extends Category1Value
      */
     public InstructionOffsetValue(int value)
     {
-        this.values = new int[] { value };
-        valuesMap.add(value);
+        this.values = new int[]{value};
     }
 
 
@@ -65,9 +64,17 @@ public class InstructionOffsetValue extends Category1Value
     public InstructionOffsetValue(int[] values)
     {
         this.values = values;
-        for (int value : values)
+        // If there are a lot of values, it's faster to use a set
+        // for the "contains" method, than doing a linear search
+        // The threshold for this is chosen by experimentation
+        // to find a balance between memory footprint and performance
+        if (values.length > 100)
         {
-            valuesMap.add(value);
+            valuesMap = new HashSet<>();
+            for (int index = 0; index < values.length; index++)
+            {
+                valuesMap.add(values[index]);
+            }
         }
     }
 
@@ -96,6 +103,17 @@ public class InstructionOffsetValue extends Category1Value
      */
     public boolean contains(int value)
     {
+        if (valuesMap == null)
+        {
+            for (int index = 0; index < values.length; index++)
+            {
+                if (values[index] == value)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
         return valuesMap.contains(value);
     }
 

--- a/base/src/main/java/proguard/evaluation/value/InstructionOffsetValue.java
+++ b/base/src/main/java/proguard/evaluation/value/InstructionOffsetValue.java
@@ -17,6 +17,9 @@
  */
 package proguard.evaluation.value;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import proguard.classfile.TypeConstants;
 
 /**
@@ -41,7 +44,8 @@ public class InstructionOffsetValue extends Category1Value
     public static final int EXCEPTION_HANDLER       = 0x20000000;
 
 
-    private int[] values;
+    private final int[] values;
+    private final Set<Integer> valuesMap = new HashSet<>();
 
 
     /**
@@ -50,6 +54,7 @@ public class InstructionOffsetValue extends Category1Value
     public InstructionOffsetValue(int value)
     {
         this.values = new int[] { value };
+        valuesMap.add(value);
     }
 
 
@@ -60,6 +65,10 @@ public class InstructionOffsetValue extends Category1Value
     public InstructionOffsetValue(int[] values)
     {
         this.values = values;
+        for (int value : values)
+        {
+            valuesMap.add(value);
+        }
     }
 
 
@@ -87,15 +96,7 @@ public class InstructionOffsetValue extends Category1Value
      */
     public boolean contains(int value)
     {
-        for (int index = 0; index < values.length; index++)
-        {
-            if (values[index] == value)
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return valuesMap.contains(value);
     }
 
 


### PR DESCRIPTION
As analyzed in https://github.com/Guardsquare/proguard/issues/283 the `contains` method is a hotspot and performance bottleneck.

Using a set for fixed lookup times drastically improved the performance. In the concret example of the referenced issue, the obfuscation runtime has been reduced from 22min to 1.2min, that's a 94% performance improvement!