### PR TITLE
Disable Java 10 testing

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -58,7 +58,8 @@ task testAllJavaVersions() { testAllTask ->
     dependsOn(test) // the usual test runs on Java 8
 
     javaVersionsForTest.each {version ->
-        task("testJava$version", type: Test) {
+    
+        if (version != 10) task("testJava$version", type: Test) {
 
             // The version of bytebuddy used by mockk only supports Java 19 experimentally so far
             if (version == 19) systemProperty 'net.bytebuddy.experimental', true


### PR DESCRIPTION
Tests running on the Java 10 JVM on the CI seem to be unstable e.g.

```
Caused by: java.lang.AssertionError: Compilation error: An exception has occurred in the compiler (10.0.2). Please file a bug against the Java compiler via the Java bug reporting page (http://bugreport.java.com/) after checking the Bug Database (http://bugs.java.com/) for duplicates. Include your program and the following diagnostic in your report. Thank you.
```