### PR TITLE
Allow initializating Kotlin metadata with IOUtil.read

### DIFF
--- a/android/src/testFixtures/kotlin/proguard/android/testutils/ClassPoolBuilder.kt
+++ b/android/src/testFixtures/kotlin/proguard/android/testutils/ClassPoolBuilder.kt
@@ -19,7 +19,7 @@ fun ClassPoolBuilder.Companion.fromSmali(smali: SmaliSource): ClassPools {
     val file = File.createTempFile("tmp", ".smali")
     file.writeText(smali.contents)
 
-    val classPool = IOUtil.read(file, false) { dataEntryReader, classPoolFiller ->
+    val classPool = IOUtil.read(file, false, true) { dataEntryReader, classPoolFiller ->
         // Convert dex files
         val dexReader = NameFilteredDataEntryReader(
             "classes*.dex",


### PR DESCRIPTION
For the `IOUtil.read` util function: instead of having to run the KotlinMetadataInitializer separately (which is not possible for library classes anyway), add a boolean to allowing choosing to initialize the Kotlin metadata.

