### PR TITLE
Add Kotlin SAM visitor interfaces

### DIFF
--- a/base/src/main/java/proguard/classfile/kotlin/visitor/KotlinClassVisitor.java
+++ b/base/src/main/java/proguard/classfile/kotlin/visitor/KotlinClassVisitor.java
@@ -1,0 +1,34 @@
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2023 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package proguard.classfile.kotlin.visitor;
+
+import proguard.classfile.Clazz;
+import proguard.classfile.kotlin.KotlinClassKindMetadata;
+import proguard.classfile.kotlin.KotlinMetadata;
+
+/**
+ * A {@link KotlinMetadataVisitor} that visits {@link KotlinClassKindMetadata}.
+ */
+public interface KotlinClassVisitor extends KotlinMetadataVisitor
+{
+    @Override
+    default void visitAnyKotlinMetadata(Clazz clazz, KotlinMetadata kotlinMetadata) { }
+
+    @Override
+    void visitKotlinClassMetadata(Clazz clazz, KotlinClassKindMetadata kotlinClassKindMetadata);
+}

--- a/base/src/main/java/proguard/classfile/kotlin/visitor/KotlinFileFacadeVisitor.java
+++ b/base/src/main/java/proguard/classfile/kotlin/visitor/KotlinFileFacadeVisitor.java
@@ -1,0 +1,34 @@
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2023 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package proguard.classfile.kotlin.visitor;
+
+import proguard.classfile.Clazz;
+import proguard.classfile.kotlin.KotlinFileFacadeKindMetadata;
+import proguard.classfile.kotlin.KotlinMetadata;
+
+/**
+ * A {@link KotlinMetadataVisitor} that visits {@link KotlinFileFacadeKindMetadata}.
+ */
+public interface KotlinFileFacadeVisitor extends KotlinMetadataVisitor
+{
+    @Override
+    default void visitAnyKotlinMetadata(Clazz clazz, KotlinMetadata kotlinMetadata) { }
+
+    @Override
+    void visitKotlinFileFacadeMetadata(Clazz clazz, KotlinFileFacadeKindMetadata kotlinFileFacadeKindMetadata);
+}

--- a/base/src/main/java/proguard/classfile/kotlin/visitor/KotlinMultiFileFacadeVisitor.java
+++ b/base/src/main/java/proguard/classfile/kotlin/visitor/KotlinMultiFileFacadeVisitor.java
@@ -1,0 +1,34 @@
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2023 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package proguard.classfile.kotlin.visitor;
+
+import proguard.classfile.Clazz;
+import proguard.classfile.kotlin.KotlinMetadata;
+import proguard.classfile.kotlin.KotlinMultiFileFacadeKindMetadata;
+
+/**
+ * A {@link KotlinMetadataVisitor} that visits {@link KotlinMultiFileFacadeKindMetadata}.
+ */
+public interface KotlinMultiFileFacadeVisitor extends KotlinMetadataVisitor
+{
+    @Override
+    default void visitAnyKotlinMetadata(Clazz clazz, KotlinMetadata kotlinMetadata) { }
+
+    @Override
+    void visitKotlinMultiFileFacadeMetadata(Clazz clazz, KotlinMultiFileFacadeKindMetadata kotlinMultiFileFacadeKindMetadata);
+}

--- a/base/src/main/java/proguard/classfile/kotlin/visitor/KotlinMultiFilePartVisitor.java
+++ b/base/src/main/java/proguard/classfile/kotlin/visitor/KotlinMultiFilePartVisitor.java
@@ -1,0 +1,34 @@
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2023 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package proguard.classfile.kotlin.visitor;
+
+import proguard.classfile.Clazz;
+import proguard.classfile.kotlin.KotlinMetadata;
+import proguard.classfile.kotlin.KotlinMultiFilePartKindMetadata;
+
+/**
+ * A {@link KotlinMetadataVisitor} that visits {@link KotlinMultiFilePartKindMetadata}.
+ */
+public interface KotlinMultiFilePartVisitor extends KotlinMetadataVisitor
+{
+    @Override
+    default void visitAnyKotlinMetadata(Clazz clazz, KotlinMetadata kotlinMetadata) { }
+
+    @Override
+    void visitKotlinMultiFilePartMetadata(Clazz clazz, KotlinMultiFilePartKindMetadata kotlinMultiFilePartKindMetadata);
+}

--- a/base/src/main/java/proguard/classfile/kotlin/visitor/KotlinSyntheticClassVisitor.java
+++ b/base/src/main/java/proguard/classfile/kotlin/visitor/KotlinSyntheticClassVisitor.java
@@ -1,0 +1,34 @@
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2023 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package proguard.classfile.kotlin.visitor;
+
+import proguard.classfile.Clazz;
+import proguard.classfile.kotlin.KotlinMetadata;
+import proguard.classfile.kotlin.KotlinSyntheticClassKindMetadata;
+
+/**
+ * A {@link KotlinMetadataVisitor} that visits {@link KotlinSyntheticClassKindMetadata}.
+ */
+public interface KotlinSyntheticClassVisitor extends KotlinMetadataVisitor
+{
+    @Override
+    default void visitAnyKotlinMetadata(Clazz clazz, KotlinMetadata kotlinMetadata) { }
+
+    @Override
+    void visitKotlinSyntheticClassMetadata(Clazz clazz, KotlinSyntheticClassKindMetadata kotlinSyntheticClassKindMetadata);
+}

--- a/docs/md/releasenotes.md
+++ b/docs/md/releasenotes.md
@@ -4,6 +4,8 @@
 
 - Increase `proguard.classfile.VersionConstants.MAX_SUPPORTED_VERSION` to `64.65535` (Java 20 + preview enabled).
 - Fix tracking of `IdentifiedReferenceValue` IDs.
+- Add new Kotlin visitor SAM interfaces: `KotlinClassVisitor`, `KotlinFileFacadeVisitor`,
+  `KotlinMultiFileFacadeVisitor`, `KotlinMultiFilePartVisitor`, `KotlinSyntheticClassVisitor`.
 
 ### API changes
 - `JvmTransferRelation` has been refactored to model `IINC` in a separate `computeIncrement` method. 


### PR DESCRIPTION
This allows compact code when one only needs to implement a visitor for a single Kotlin metadata kind.

For example without this change:

```kotlin
    programClassPool.classesAccept(
        ReferencedKotlinMetadataVisitor(
            object : KotlinMetadataVisitor {
                override fun visitAnyKotlinMetadata(clazz: Clazz, kotlinMetadata: KotlinMetadata) {}

                override fun visitKotlinFileFacadeMetadata(clazz: Clazz, declarationContainer: KotlinFileFacadeKindMetadata) {
                    declarationContainer.functionsAccept(clazz) { _, _, function ->
                        function.name = function.referencedMethod.getName(clazz)
                    }
                }
            }
        )
    )
```

with this change:

```kotlin
    programClassPool.classesAccept(
        ReferencedKotlinMetadataVisitor(
            KotlinFileFacadeVisitor { clazz, declarationContainer ->
                declarationContainer.functionsAccept(clazz) { _, _, function ->
                    function.name = function.referencedMethod.getName(clazz)
                }
            }
        )
    )
```
