### PR TITLE
Add exception handling to DominatorCalculator

### DIFF
--- a/base/src/main/java/proguard/analysis/CallResolver.java
+++ b/base/src/main/java/proguard/analysis/CallResolver.java
@@ -245,6 +245,7 @@ implements   AttributeVisitor,
                         Supplier<Boolean> shouldAnalyzeNextCodeAttribute,
                         boolean skipIncompleteCalls,
                         ValueFactory arrayValueFactory,
+                        boolean ignoreExceptions,
                         CallVisitor... visitors)
     {
         this.programClassPool               = programClassPool;
@@ -255,7 +256,7 @@ implements   AttributeVisitor,
         this.shouldAnalyzeNextCodeAttribute = shouldAnalyzeNextCodeAttribute;
         this.skipIncompleteCalls            = skipIncompleteCalls;
         this.visitors                       = Arrays.asList(visitors);
-        dominatorCalculator                 = new DominatorCalculator();
+        dominatorCalculator                 = new DominatorCalculator(ignoreExceptions);
 
         // Initialize the multitype evaluator.
         ValueFactory multiTypeValueFactory = includeSubClasses ?
@@ -974,6 +975,7 @@ implements   AttributeVisitor,
         private       Supplier<Boolean> shouldAnalyzeNextCodeAttribute = () -> true;
         private       boolean           skipIncompleteCalls            = true;
         private       ValueFactory      arrayValueFactory              = new ArrayReferenceValueFactory();
+        private       boolean           ignoreExceptions               = true;
 
         public Builder(ClassPool programClassPool, ClassPool libraryClassPool, CallGraph callGraph, CallVisitor... visitors)
         {
@@ -1076,6 +1078,15 @@ implements   AttributeVisitor,
             return this;
         }
 
+        /**
+         * If false, exceptions will be taken into account during control flow analysis.
+         */
+        public Builder setIgnoreExceptions(boolean ignoreExceptions)
+        {
+            this.ignoreExceptions = ignoreExceptions;
+            return this;
+        }
+
         public CallResolver build()
         {
             return new CallResolver(programClassPool,
@@ -1089,6 +1100,7 @@ implements   AttributeVisitor,
                                     shouldAnalyzeNextCodeAttribute,
                                     skipIncompleteCalls,
                                     arrayValueFactory,
+                                    ignoreExceptions,
                                     visitors);
 
         }

--- a/base/src/test/kotlin/proguard/analysis/DominatorCalculatorTest.kt
+++ b/base/src/test/kotlin/proguard/analysis/DominatorCalculatorTest.kt
@@ -494,10 +494,11 @@ class DominatorCalculatorTest : FreeSpec({
             // try start
             Instruction.OP_BIPUSH, 44, // 4  bipush 44
             // try end
-            Instruction.OP_GOTO, 0, 5, // 6  goto 11 (+5)
+            Instruction.OP_BIPUSH, 45, // 6  bipush 45
+            Instruction.OP_RETURN,     // 8  return
             // catch
             Instruction.OP_BIPUSH, 45, // 9  bipush 45
-            Instruction.OP_RETURN,     // 11  return
+            Instruction.OP_GOTO, -1, -3, // 11  goto 8 (-3)
         )
         val exceptions = arrayOf(
             ExceptionInfo(0, 2, 9, 1),
@@ -526,8 +527,10 @@ class DominatorCalculatorTest : FreeSpec({
             | / 6
             |/  |
             9   |
+            |   |
+            11  |
              \ /
-              11
+              8
               |
              EXIT
          */
@@ -538,8 +541,9 @@ class DominatorCalculatorTest : FreeSpec({
         calculator.getDominators(4) shouldBe setOf(ENTRY_NODE_OFFSET, 0, 2, 4)
         calculator.getDominators(6) shouldBe setOf(ENTRY_NODE_OFFSET, 0, 2, 4, 6)
         calculator.getDominators(9) shouldBe setOf(ENTRY_NODE_OFFSET, 9)
-        calculator.getDominators(11) shouldBe setOf(ENTRY_NODE_OFFSET, 11)
-        calculator.getDominators(EXIT_NODE_OFFSET) shouldBe setOf(ENTRY_NODE_OFFSET, 11, EXIT_NODE_OFFSET)
+        calculator.getDominators(11) shouldBe setOf(ENTRY_NODE_OFFSET, 9, 11)
+        calculator.getDominators(8) shouldBe setOf(ENTRY_NODE_OFFSET, 8)
+        calculator.getDominators(EXIT_NODE_OFFSET) shouldBe setOf(ENTRY_NODE_OFFSET, 8, EXIT_NODE_OFFSET)
     }
 
     "Unknown offsets should not have dominators" {

--- a/base/src/test/kotlin/proguard/analysis/DominatorCalculatorTest.kt
+++ b/base/src/test/kotlin/proguard/analysis/DominatorCalculatorTest.kt
@@ -488,16 +488,16 @@ class DominatorCalculatorTest : FreeSpec({
         // In Java, nested try blocks can compile to multiple exception handlers with a goto between them.
         val code = byteArrayOf(
             // try start
-            Instruction.OP_BIPUSH, 42,   // 0  bipush 42
+            Instruction.OP_BIPUSH, 42, //   0  bipush 42
             // try end
-            Instruction.OP_BIPUSH, 43,   // 2  bipush 43
+            Instruction.OP_BIPUSH, 43, //   2  bipush 43
             // try start
-            Instruction.OP_BIPUSH, 44,   // 4  bipush 44
+            Instruction.OP_BIPUSH, 44, //   4  bipush 44
             // try end
-            Instruction.OP_BIPUSH, 45,   // 6  bipush 45
-            Instruction.OP_RETURN,       // 8  return
+            Instruction.OP_BIPUSH, 45, //   6  bipush 45
+            Instruction.OP_RETURN, //       8  return
             // catch
-            Instruction.OP_BIPUSH, 45,   // 9  bipush 45
+            Instruction.OP_BIPUSH, 45, //   9  bipush 45
             Instruction.OP_GOTO, -1, -3, // 11  goto 8 (-3)
         )
         val exceptions = arrayOf(

--- a/base/src/test/kotlin/proguard/analysis/DominatorCalculatorTest.kt
+++ b/base/src/test/kotlin/proguard/analysis/DominatorCalculatorTest.kt
@@ -488,16 +488,16 @@ class DominatorCalculatorTest : FreeSpec({
         // In Java, nested try blocks can compile to multiple exception handlers with a goto between them.
         val code = byteArrayOf(
             // try start
-            Instruction.OP_BIPUSH, 42, // 0  bipush 42
+            Instruction.OP_BIPUSH, 42,   // 0  bipush 42
             // try end
-            Instruction.OP_BIPUSH, 43, // 2  bipush 43
+            Instruction.OP_BIPUSH, 43,   // 2  bipush 43
             // try start
-            Instruction.OP_BIPUSH, 44, // 4  bipush 44
+            Instruction.OP_BIPUSH, 44,   // 4  bipush 44
             // try end
-            Instruction.OP_BIPUSH, 45, // 6  bipush 45
-            Instruction.OP_RETURN,     // 8  return
+            Instruction.OP_BIPUSH, 45,   // 6  bipush 45
+            Instruction.OP_RETURN,       // 8  return
             // catch
-            Instruction.OP_BIPUSH, 45, // 9  bipush 45
+            Instruction.OP_BIPUSH, 45,   // 9  bipush 45
             Instruction.OP_GOTO, -1, -3, // 11  goto 8 (-3)
         )
         val exceptions = arrayOf(

--- a/base/src/test/kotlin/proguard/analysis/DominatorCalculatorTest.kt
+++ b/base/src/test/kotlin/proguard/analysis/DominatorCalculatorTest.kt
@@ -28,6 +28,7 @@ import proguard.classfile.Clazz
 import proguard.classfile.ProgramClass
 import proguard.classfile.ProgramMethod
 import proguard.classfile.attribute.CodeAttribute
+import proguard.classfile.attribute.ExceptionInfo
 import proguard.classfile.attribute.visitor.AttributeVisitor
 import proguard.classfile.instruction.Instruction
 import proguard.classfile.visitor.ClassVisitor
@@ -379,6 +380,108 @@ class DominatorCalculatorTest : FreeSpec({
             43,
             EXIT_NODE_OFFSET
         )
+    }
+
+    "Try block at start of code" {
+        val code = byteArrayOf(
+            // try start
+            Instruction.OP_BIPUSH, 42, // 0  bipush 42
+            Instruction.OP_BIPUSH, 43, // 2  bipush 43
+            // try end
+            Instruction.OP_GOTO, 0, 7, // 4  goto 11 (+7)
+            // catch
+            Instruction.OP_BIPUSH, 44, // 7  bipush 44
+            Instruction.OP_BIPUSH, 45, // 9  bipush 45
+            Instruction.OP_BIPUSH, 46, // 11 bipush 46
+            Instruction.OP_RETURN //      13 return
+        )
+        val exceptions = arrayOf(ExceptionInfo(0, 4, 7, 1))
+        val clazz = NamedClass("Test")
+        val method = NamedMember("", "()V")
+        val codeAttribute = CodeAttribute(
+            0, 1, 0, code.size, code,
+            exceptions.size, exceptions, 0, arrayOf()
+        )
+
+        val calculator = DominatorCalculator(false)
+        codeAttribute.accept(clazz, method, calculator)
+
+        /*
+            ENTRY
+             / \
+            0   7
+            |   |
+            2   9
+            |   |
+            4   |
+             \ /
+              11
+              |
+              13
+              |
+             EXIT
+         */
+
+        calculator.getDominators(ENTRY_NODE_OFFSET) shouldBe setOf(ENTRY_NODE_OFFSET)
+        calculator.getDominators(0) shouldBe setOf(ENTRY_NODE_OFFSET, 0)
+        calculator.getDominators(2) shouldBe setOf(ENTRY_NODE_OFFSET, 0, 2)
+        calculator.getDominators(4) shouldBe setOf(ENTRY_NODE_OFFSET, 0, 2, 4)
+        calculator.getDominators(7) shouldBe setOf(ENTRY_NODE_OFFSET, 7)
+        calculator.getDominators(9) shouldBe setOf(ENTRY_NODE_OFFSET, 7, 9)
+        calculator.getDominators(11) shouldBe setOf(ENTRY_NODE_OFFSET, 11)
+        calculator.getDominators(13) shouldBe setOf(ENTRY_NODE_OFFSET, 11, 13)
+        calculator.getDominators(EXIT_NODE_OFFSET) shouldBe setOf(ENTRY_NODE_OFFSET, 11, 13, EXIT_NODE_OFFSET)
+    }
+
+    "Try block partway through code" {
+        val code = byteArrayOf(
+            Instruction.OP_BIPUSH, 42, // 0  bipush 42
+            // try start
+            Instruction.OP_BIPUSH, 43, // 2  bipush 43
+            // try end
+            Instruction.OP_GOTO, 0, 7, // 4  goto 11 (+7)
+            // catch
+            Instruction.OP_BIPUSH, 44, // 7  bipush 44
+            Instruction.OP_BIPUSH, 45, // 9  bipush 45
+            Instruction.OP_BIPUSH, 46, // 11 bipush 46
+            Instruction.OP_RETURN //      13 return
+        )
+        val exceptions = arrayOf(ExceptionInfo(2, 4, 7, 1))
+        val clazz = NamedClass("Test")
+        val method = NamedMember("", "()V")
+        val codeAttribute = CodeAttribute(
+            0, 1, 0, code.size, code,
+            exceptions.size, exceptions, 0, arrayOf()
+        )
+
+        val calculator = DominatorCalculator(false)
+        codeAttribute.accept(clazz, method, calculator)
+
+        /*
+            ENTRY
+              |
+              0
+             / \
+            2   7
+            |   |
+            4   9
+             \ /
+              11
+              |
+              13
+              |
+             EXIT
+         */
+
+        calculator.getDominators(ENTRY_NODE_OFFSET) shouldBe setOf(ENTRY_NODE_OFFSET)
+        calculator.getDominators(0) shouldBe setOf(ENTRY_NODE_OFFSET, 0)
+        calculator.getDominators(2) shouldBe setOf(ENTRY_NODE_OFFSET, 0, 2)
+        calculator.getDominators(4) shouldBe setOf(ENTRY_NODE_OFFSET, 0, 2, 4)
+        calculator.getDominators(7) shouldBe setOf(ENTRY_NODE_OFFSET, 0, 7)
+        calculator.getDominators(9) shouldBe setOf(ENTRY_NODE_OFFSET, 0, 7, 9)
+        calculator.getDominators(11) shouldBe setOf(ENTRY_NODE_OFFSET, 0, 11)
+        calculator.getDominators(13) shouldBe setOf(ENTRY_NODE_OFFSET, 0, 11, 13)
+        calculator.getDominators(EXIT_NODE_OFFSET) shouldBe setOf(ENTRY_NODE_OFFSET, 0, 11, 13, EXIT_NODE_OFFSET)
     }
 
     "Unknown offsets should not have dominators" {

--- a/base/src/test/kotlin/proguard/analysis/DominatorCalculatorTest.kt
+++ b/base/src/test/kotlin/proguard/analysis/DominatorCalculatorTest.kt
@@ -484,6 +484,64 @@ class DominatorCalculatorTest : FreeSpec({
         calculator.getDominators(EXIT_NODE_OFFSET) shouldBe setOf(ENTRY_NODE_OFFSET, 0, 11, 13, EXIT_NODE_OFFSET)
     }
 
+    "Different try blocks pointing to the same handler" {
+        // In Java, nested try blocks can compile to multiple exception handlers with a goto between them.
+        val code = byteArrayOf(
+            // try start
+            Instruction.OP_BIPUSH, 42, // 0  bipush 42
+            // try end
+            Instruction.OP_BIPUSH, 43, // 2  bipush 43
+            // try start
+            Instruction.OP_BIPUSH, 44, // 4  bipush 44
+            // try end
+            Instruction.OP_GOTO, 0, 5, // 6  goto 11 (+5)
+            // catch
+            Instruction.OP_BIPUSH, 45, // 9  bipush 45
+            Instruction.OP_RETURN,     // 11  return
+        )
+        val exceptions = arrayOf(
+            ExceptionInfo(0, 2, 9, 1),
+            ExceptionInfo(4, 6, 9, 1),
+        )
+
+        val clazz = NamedClass("Test")
+        val method = NamedMember("", "()V")
+        val codeAttribute = CodeAttribute(
+            0, 1, 0, code.size, code,
+            exceptions.size, exceptions, 0, arrayOf()
+        )
+
+        val calculator = DominatorCalculator(false)
+        codeAttribute.accept(clazz, method, calculator)
+
+        /*
+            ENTRY
+             / \
+            |   0
+            |  /|
+            | / 2
+            |/  |
+            |   4
+            |  /|
+            | / 6
+            |/  |
+            9   |
+             \ /
+              11
+              |
+             EXIT
+         */
+
+        calculator.getDominators(ENTRY_NODE_OFFSET) shouldBe setOf(ENTRY_NODE_OFFSET)
+        calculator.getDominators(0) shouldBe setOf(ENTRY_NODE_OFFSET, 0)
+        calculator.getDominators(2) shouldBe setOf(ENTRY_NODE_OFFSET, 0, 2)
+        calculator.getDominators(4) shouldBe setOf(ENTRY_NODE_OFFSET, 0, 2, 4)
+        calculator.getDominators(6) shouldBe setOf(ENTRY_NODE_OFFSET, 0, 2, 4, 6)
+        calculator.getDominators(9) shouldBe setOf(ENTRY_NODE_OFFSET, 9)
+        calculator.getDominators(11) shouldBe setOf(ENTRY_NODE_OFFSET, 11)
+        calculator.getDominators(EXIT_NODE_OFFSET) shouldBe setOf(ENTRY_NODE_OFFSET, 11, EXIT_NODE_OFFSET)
+    }
+
     "Unknown offsets should not have dominators" {
         val code = byteArrayOf(
             Instruction.OP_BIPUSH, 42, // 0  bipush 42


### PR DESCRIPTION
Exceptions complicate control flow somewhat, so this PR adjusts the `DominatorCalculator` to take that into account. This functionality is off by default, so that it won't unexpectedly break things. It can be turned on by passing `false` to `DominatorCalculator`'s constructor, or in the case of the `CallResolver`, through the builder's `setIgnoreExceptions` method.