### PR TITLE
feat: array instruction on object throws ArrayInstructionOnWrongTypeException

### DIFF
--- a/base/src/main/java/proguard/evaluation/exception/ArrayInstructionException.java
+++ b/base/src/main/java/proguard/evaluation/exception/ArrayInstructionException.java
@@ -1,0 +1,9 @@
+package proguard.evaluation.exception;
+
+public class ArrayInstructionException extends PartialEvaluatorException
+{
+    public ArrayInstructionException(String genericMessage, Throwable cause)
+    {
+        super(genericMessage, cause);
+    }
+}

--- a/base/src/main/java/proguard/evaluation/exception/ArrayInstructionOnWrongTypeException.java
+++ b/base/src/main/java/proguard/evaluation/exception/ArrayInstructionOnWrongTypeException.java
@@ -1,0 +1,14 @@
+package proguard.evaluation.exception;
+
+import proguard.evaluation.value.Value;
+
+public class ArrayInstructionOnWrongTypeException extends ArrayInstructionException
+{
+    protected final Value wrongValue;
+
+    public ArrayInstructionOnWrongTypeException(Value wrongValue)
+    {
+        super("Invalid reference provided to arrayInstruction. Expected arrayReference but found: "+wrongValue.toString()+".", null);
+        this.wrongValue = wrongValue;
+    }
+}

--- a/base/src/main/java/proguard/evaluation/exception/PartialEvaluatorException.java
+++ b/base/src/main/java/proguard/evaluation/exception/PartialEvaluatorException.java
@@ -1,0 +1,37 @@
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2021 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proguard.evaluation.exception;
+
+import proguard.evaluation.PartialEvaluator;
+import proguard.exception.ProguardCoreException;
+
+import java.util.Collections;
+
+/**
+ * Represents an exception when the `PartialEvaluator` encounters a semantically incorrect java bytecode instruction.
+ *
+ * @see PartialEvaluator
+ */
+public class PartialEvaluatorException extends ProguardCoreException
+{
+    public PartialEvaluatorException(String genericMessage, Throwable cause)
+    {
+        super(genericMessage, 4, Collections.emptyList(), cause);
+    }
+}

--- a/base/src/main/java/proguard/evaluation/value/TypedReferenceValue.java
+++ b/base/src/main/java/proguard/evaluation/value/TypedReferenceValue.java
@@ -18,9 +18,11 @@
 package proguard.evaluation.value;
 
 import proguard.classfile.*;
+import proguard.classfile.constant.Constant;
 import proguard.classfile.util.ClassUtil;
 import proguard.classfile.visitor.ClassCollector;
 import proguard.evaluation.IncompleteClassHierarchyException;
+import proguard.evaluation.exception.ArrayInstructionOnWrongTypeException;
 
 import java.util.*;
 
@@ -571,6 +573,54 @@ public class TypedReferenceValue extends ReferenceValue
         return count;
     }
 
+    @Override
+    public void arrayStore(IntegerValue indexValue, Value value)
+    {
+        if (type.charAt(0) != '[')
+        {
+            throw new ArrayInstructionOnWrongTypeException(this);
+        }
+    }
+
+    @Override
+    public DoubleValue doubleArrayLoad(IntegerValue indexValue, ValueFactory valueFactory)
+    {
+        if (type.charAt(0) != '[')
+        {
+            throw new ArrayInstructionOnWrongTypeException(this);
+        }
+        return super.doubleArrayLoad(indexValue, valueFactory);
+    }
+
+    @Override
+    public IntegerValue integerArrayLoad(IntegerValue indexValue, ValueFactory valueFactory)
+    {
+        if (type.charAt(0) != '[')
+        {
+            throw new ArrayInstructionOnWrongTypeException(this);
+        }
+        return super.integerArrayLoad(indexValue, valueFactory);
+    }
+
+    @Override
+    public LongValue longArrayLoad(IntegerValue indexValue, ValueFactory valueFactory)
+    {
+        if (type.charAt(0) != '[')
+        {
+            throw new ArrayInstructionOnWrongTypeException(this);
+        }
+        return super.longArrayLoad(indexValue, valueFactory);
+    }
+
+    @Override
+    public FloatValue floatArrayLoad(IntegerValue indexValue, ValueFactory valueFactory)
+    {
+        if (type.charAt(0) != '[')
+        {
+            throw new ArrayInstructionOnWrongTypeException(this);
+        }
+        return super.floatArrayLoad(indexValue, valueFactory);
+    }
 
     public int equal(TypedReferenceValue other)
     {

--- a/base/src/test/kotlin/proguard/analysis/PartialEvaluatorErrorsTest.kt
+++ b/base/src/test/kotlin/proguard/analysis/PartialEvaluatorErrorsTest.kt
@@ -1,5 +1,6 @@
 package proguard.analysis
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.FreeSpec
 import proguard.classfile.AccessConstants
@@ -19,8 +20,10 @@ import proguard.classfile.visitor.NamedMethodVisitor
 import proguard.evaluation.BasicInvocationUnit
 import proguard.evaluation.PartialEvaluator
 import proguard.evaluation.ParticularReferenceValueFactory
+import proguard.evaluation.exception.ArrayInstructionOnWrongTypeException
 import proguard.evaluation.value.DetailedArrayValueFactory
 import proguard.evaluation.value.ParticularValueFactory
+import proguard.evaluation.value.TypedReferenceValueFactory
 
 /**
  * These test check that various invalid code snippets correctly throw exceptions from the
@@ -154,6 +157,81 @@ class PartialEvaluatorErrorsTest : FreeSpec({
 
             shouldThrowAny { evaluateProgramClass(programClass, PartialEvaluator(), "test", "()V") }
         }
+
+        "Load an int into an int array but mistakenly give object ref" {
+            // Only throws an error when value factory is of type TypedReferenceValueFactory
+
+            // It is possible to perform the iastore instruction when the `arrayref` isn't actually an array reference.
+            // In this example the reference is a reference to the class itself and this is no issue according
+            // to the PartialEvaluator:
+            // [5] iconst_5
+            //  Vars:  [P0:LPartialEvaluatorDummy;!#0]
+            //  Stack: [1:[I?=![1]#0{0}][3:LPartialEvaluatorDummy;!#0][4:0][5:5]
+            // [6] iastore
+            //  Vars:  [P0:LPartialEvaluatorDummy;!#0]
+            //  Stack: [1:[I?=![1]#0{0}]
+            // [7] areturn
+            //      is branching to :
+            //  Vars:  [P0:LPartialEvaluatorDummy;!#0]
+            //  Stack:
+            val programClass = buildClass()
+                .addMethod(AccessConstants.PUBLIC, "test", "()Ljava/lang/Object;", 50) {
+                    it
+                        .iconst_1()
+                        .newarray(Instruction.ARRAY_T_INT.toInt())
+                        .aload_0()
+                        .iconst_0()
+                        .iconst_5()
+                        .iastore()
+                        .areturn()
+                }
+                .programClass
+
+            shouldThrow<ArrayInstructionOnWrongTypeException> {
+                evaluateProgramClass(
+                    programClass,
+                    PartialEvaluator(TypedReferenceValueFactory()),
+                    "test",
+                    "()Ljava/lang/Object;",
+                )
+            }
+        }
+
+        "Load an int from an int array but mistakenly give object ref" {
+            // Only throws an error when value factory is of type TypedReferenceValueFactory
+
+            // It is possible to perform the iastore instruction when the `arrayref` isn't actually an array reference.
+            // In this example the reference is a reference to the class itself and this is no issue according
+            // to the PartialEvaluator:
+            // [5] iconst_5
+            //  Vars:  [P0:LPartialEvaluatorDummy;!#0]
+            //  Stack: [1:[I?=![1]#0{0}][3:LPartialEvaluatorDummy;!#0][4:0][5:5]
+            // [6] iastore
+            //  Vars:  [P0:LPartialEvaluatorDummy;!#0]
+            //  Stack: [1:[I?=![1]#0{0}]
+            // [7] areturn
+            //      is branching to :
+            //  Vars:  [P0:LPartialEvaluatorDummy;!#0]
+            //  Stack:
+            val programClass = buildClass()
+                .addMethod(AccessConstants.PUBLIC, "test", "()V", 50) {
+                    it
+                        .aload_0()
+                        .iconst_0()
+                        .iaload()
+                        .return_()
+                }
+                .programClass
+
+            shouldThrow<ArrayInstructionOnWrongTypeException> {
+                evaluateProgramClass(
+                    programClass,
+                    PartialEvaluator(TypedReferenceValueFactory()),
+                    "test",
+                    "()V",
+                )
+            }
+        }
     }
 
     /**
@@ -180,46 +258,6 @@ class PartialEvaluatorErrorsTest : FreeSpec({
                         .iconst_0()
                         .aload_0()
                         .aastore()
-                        .areturn()
-                }
-                .programClass
-
-            evaluateProgramClass(
-                programClass,
-                PartialEvaluator(
-                    ParticularValueFactory(
-                        DetailedArrayValueFactory(),
-                        ParticularReferenceValueFactory(),
-                    ),
-                ),
-                "test",
-                "()Ljava/lang/Object;",
-            )
-        }
-
-        "Load a reference into reference array but mistakenly give object ref" {
-            // It is possible to perform the iastore instruction when the `arrayref` isn't actually an array reference.
-            // In this example the reference is a reference to the class itself and this is no issue according
-            // to the PartialEvaluator:
-            // [5] iconst_5
-            //  Vars:  [P0:LPartialEvaluatorDummy;!#0]
-            //  Stack: [1:[I?=![1]#0{0}][3:LPartialEvaluatorDummy;!#0][4:0][5:5]
-            // [6] iastore
-            //  Vars:  [P0:LPartialEvaluatorDummy;!#0]
-            //  Stack: [1:[I?=![1]#0{0}]
-            // [7] areturn
-            //      is branching to :
-            //  Vars:  [P0:LPartialEvaluatorDummy;!#0]
-            //  Stack:
-            val programClass = buildClass()
-                .addMethod(AccessConstants.PUBLIC, "test", "()Ljava/lang/Object;", 50) {
-                    it
-                        .iconst_1()
-                        .newarray(Instruction.ARRAY_T_INT.toInt())
-                        .aload_0()
-                        .iconst_0()
-                        .iconst_5()
-                        .iastore()
                         .areturn()
                 }
                 .programClass


### PR DESCRIPTION
This PR adds an exception being thrown when a load or store operation is called, but the first stack element is not an array reference. Merging this PR should be done with care since it throws an exception where previously there was non.