### PR TITLE
Add unknown superclass names to IncompleteClassHierarchyException

### DIFF
--- a/base/src/main/java/proguard/evaluation/value/TypedReferenceValue.java
+++ b/base/src/main/java/proguard/evaluation/value/TypedReferenceValue.java
@@ -20,6 +20,7 @@ package proguard.evaluation.value;
 import proguard.classfile.*;
 import proguard.classfile.util.ClassUtil;
 import proguard.classfile.visitor.ClassCollector;
+import proguard.classfile.visitor.ClassVisitor;
 import proguard.evaluation.exception.IncompleteClassHierarchyException;
 
 import java.util.*;
@@ -515,11 +516,29 @@ public class TypedReferenceValue extends ReferenceValue
 
         if (commonClass == null)
         {
+            Set<String> unknownClasses1 = new HashSet<>();
+            class1.hierarchyAccept(!interfaces,
+                    !interfaces,
+                    interfaces,
+                    false,
+                    new UnknownSuperClassNameCollector(unknownClasses1));
+
+            Set<String> unknownClasses2 = new HashSet<>();
+            class2.hierarchyAccept(!interfaces,
+                    !interfaces,
+                    interfaces,
+                    false,
+                    new UnknownSuperClassNameCollector(unknownClasses2));
+
             throw new IncompleteClassHierarchyException("Can't find common super class of ["+
                                                         externalClassName(class1.getName()) +"] (with "+superClasses1Count +" known super classes: " +
-                                                        superClasses1.stream().map(clazz -> externalClassName(clazz.getName())).collect(joining(", ")) + ") and ["+
+                                                        superClasses1.stream().map(clazz -> externalClassName(clazz.getName())).collect(joining(", ")) +
+                                                        (!unknownClasses1.isEmpty() ? " and " + unknownClasses1.size() + " unknown classes: " + unknownClasses1.stream().map(ClassUtil::externalClassName).collect(joining(", ")) : "") +
+                                                        ") and ["+
                                                         externalClassName(class2.getName())+"] (with "+superClasses2Count+" known super classes: " +
-                                                        superClasses2.stream().map(clazz -> externalClassName(clazz.getName())).collect(joining(", ")) + ")");
+                                                        superClasses2.stream().map(clazz -> externalClassName(clazz.getName())).collect(joining(", ")) +
+                                                        (!unknownClasses2.isEmpty() ? " and " + unknownClasses2.size() + " unknown classes: " + unknownClasses2.stream().map(ClassUtil::externalClassName).collect(joining(", ")) : "") +
+                                                        ")");
         }
 
         if (DEBUG)
@@ -528,6 +547,25 @@ public class TypedReferenceValue extends ReferenceValue
         }
 
         return commonClass;
+    }
+
+    private static class UnknownSuperClassNameCollector implements ClassVisitor
+    {
+        private final Collection<String> unknownSuperClassNames;
+
+        UnknownSuperClassNameCollector(Collection<String> unknownSuperClassNames)
+        {
+            this.unknownSuperClassNames = unknownSuperClassNames;
+        }
+
+        @Override
+        public void visitAnyClass(Clazz clazz)
+        {
+            if (clazz.getSuperName() != null && clazz.getSuperClass() == null)
+            {
+                unknownSuperClassNames.add(clazz.getSuperName());
+            }
+        }
     }
 
 

--- a/base/src/test/kotlin/proguard/MultiTypeTest.kt
+++ b/base/src/test/kotlin/proguard/MultiTypeTest.kt
@@ -180,8 +180,6 @@ class MultiTypeTest : FreeSpec({
             }
 
             exception.message shouldContain "1 unknown classes: RemovedSuper"
-
-            allowIncompleteClassHierarchy.setBoolean(TypedReferenceValue(null, null, true, true), false)
         }
         "No super class" {
             // Allow incomplete Class Hierarchies

--- a/base/src/test/kotlin/proguard/MultiTypeTest.kt
+++ b/base/src/test/kotlin/proguard/MultiTypeTest.kt
@@ -7,10 +7,13 @@
 
 package proguard
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import proguard.evaluation.BasicInvocationUnit
 import proguard.evaluation.PartialEvaluator
+import proguard.evaluation.exception.IncompleteClassHierarchyException
 import proguard.evaluation.value.MultiTypedReferenceValue
 import proguard.evaluation.value.MultiTypedReferenceValueFactory
 import proguard.evaluation.value.ParticularIntegerValue
@@ -159,6 +162,26 @@ class MultiTypeTest : FreeSpec({
             s.generalizedType.type shouldBe "LSuper;"
             s.isNull shouldBe Value.NEVER
             s.potentialTypes.map { it.type }.toSet() shouldBe setOf("LA;", "LB;")
+        }
+        "No super class with exception" {
+            // Don't allow incomplete Class Hierarchies
+            val allowIncompleteClassHierarchy = TypedReferenceValue::class.java.getDeclaredField("ALLOW_INCOMPLETE_CLASS_HIERARCHY")
+            allowIncompleteClassHierarchy.isAccessible = true
+            allowIncompleteClassHierarchy.setBoolean(TypedReferenceValue(null, null, true, true), false)
+
+            val exception = shouldThrow<IncompleteClassHierarchyException> {
+                PartialEvaluatorUtil.evaluate(
+                    "Target",
+                    "noSuperClass",
+                    "(Z)V",
+                    classPool,
+                    partialEvaluator
+                )
+            }
+
+            exception.message shouldContain "1 unknown classes: RemovedSuper"
+
+            allowIncompleteClassHierarchy.setBoolean(TypedReferenceValue(null, null, true, true), false)
         }
         "No super class" {
             // Allow incomplete Class Hierarchies


### PR DESCRIPTION
Improve the error message from the PartialEvaluator when there are missing superclasses by showing the names of the missing classes.