### PR TITLE
Add registerSubroutineReturn state

### DIFF
--- a/base/src/main/java/proguard/evaluation/PartialEvaluator.java
+++ b/base/src/main/java/proguard/evaluation/PartialEvaluator.java
@@ -1107,6 +1107,8 @@ implements   AttributeVisitor,
                 {
                     // Let the partial evaluator that has called the subroutine
                     // handle the evaluation after the return.
+                    stateTracker.registerSubroutineReturn(clazz, method, instructionOffset, variables, stack);
+
                     pushCallingInstructionBlock(new TracedVariables(variables),
                             new TracedStack(stack),
                             instructionOffset);

--- a/base/src/main/java/proguard/evaluation/PartialEvaluator.java
+++ b/base/src/main/java/proguard/evaluation/PartialEvaluator.java
@@ -1107,7 +1107,7 @@ implements   AttributeVisitor,
                 {
                     // Let the partial evaluator that has called the subroutine
                     // handle the evaluation after the return.
-                    stateTracker.registerSubroutineReturn(clazz, method, instructionOffset, variables, stack);
+                    if (stateTracker != null) stateTracker.registerSubroutineReturn(clazz, method, instructionOffset, variables, stack);
 
                     pushCallingInstructionBlock(new TracedVariables(variables),
                             new TracedStack(stack),

--- a/base/src/main/java/proguard/evaluation/util/DebugPrinter.java
+++ b/base/src/main/java/proguard/evaluation/util/DebugPrinter.java
@@ -323,6 +323,12 @@ public class DebugPrinter implements PartialEvaluatorStateTracker
     }
 
     @Override
+    public void registerSubroutineReturn(Clazz clazz, Method method, int returnOffset, TracedVariables returnVariables, TracedStack returnStack)
+    {
+        System.out.println("Subroutine will return to "+returnOffset+".");
+    }
+
+    @Override
     public void generalizeSubroutine(Clazz clazz, Method method, TracedVariables startVariables, TracedStack startStack, int subroutineStart, int subroutineEnd)
     {
         if (printDebugInfo)

--- a/base/src/main/java/proguard/evaluation/util/PartialEvaluatorStateTracker.java
+++ b/base/src/main/java/proguard/evaluation/util/PartialEvaluatorStateTracker.java
@@ -171,6 +171,11 @@ public interface PartialEvaluatorStateTracker
     void startSubroutine(Clazz clazz, Method method, TracedVariables startVariables, TracedStack startStack, int subroutineStart, int subroutineEnd);
 
     /**
+     * The current instruction was RET and the partial evaluator pushes the return address to the branch stack of the calling partial evaluator
+     */
+    void registerSubroutineReturn(Clazz clazz, Method method, int returnOffset, TracedVariables returnVariables, TracedStack returnStack);
+
+    /**
      * The partial evaluator will start generalizing the results of the evaluated subroutine.
      */
     void generalizeSubroutine(Clazz clazz, Method method, TracedVariables startVariables, TracedStack startStack, int subroutineStart, int subroutineEnd);

--- a/docs/md/partialevaluator.md
+++ b/docs/md/partialevaluator.md
@@ -551,8 +551,8 @@ stateDiagram-v2
                     definitiveBranch --> BR6
                     BR6: Instruction was JSR or JSR_W?
                     BR3 --> BR6 : No
-                    Repeat: Go to next instruction
-                    BR6 --> Repeat: No
+                    BR_RET: Instruction was RET?
+                    BR6 --> BR_RET
                     L5: Instruction was subroutine invocation
                     BR6 --> L5: Yes
                     state L5 {
@@ -564,7 +564,12 @@ stateDiagram-v2
                         generalizeSubroutine --> endSubroutine
                         endSubroutine --> [*]
                     }
-                    L5 --> Repeat
+                    L5 --> [*]
+                    Repeat: Go to next instruction
+                    BR_RET --> Repeat: No
+                    REG_RET: registerSubroutineReturn 
+                    BR_RET --> REG_RET: Yes
+                    REG_RET --> [*]
 
                 }
                 L3 --> instructionBlockDone


### PR DESCRIPTION
While looking into https://github.com/Mouwrice/proguard-core-visualizer/issues/50 I found that there was still an error in the handling of JSR instructions. (Well, in this case it was actually its partner, `RET`) This PR adds another state callback and fixes the graph accordingly.