### PR TITLE
feat: pretty error for stack size computer

### DIFF
--- a/base/src/main/java/proguard/classfile/exception/NegativeStackSizeException.java
+++ b/base/src/main/java/proguard/classfile/exception/NegativeStackSizeException.java
@@ -1,0 +1,47 @@
+package proguard.classfile.exception;
+
+import proguard.classfile.Clazz;
+import proguard.classfile.Method;
+import proguard.classfile.instruction.Instruction;
+import proguard.classfile.instruction.InstructionFactory;
+import proguard.exception.ErrorId;
+import proguard.exception.ProguardCoreException;
+
+
+public class NegativeStackSizeException extends ProguardCoreException
+{
+    private final Clazz clazz;
+    private final Method method;
+    private final Instruction instruction;
+    private final int instructionOffset;
+
+    public NegativeStackSizeException(Clazz clazz, Method method, Instruction instruction, int instructionOffset)
+    {
+        super(ErrorId.NEGATIVE_STACK_SIZE, "Stack size becomes negative after instruction %s in [%s.%s%s]",
+                instruction.toString(clazz, instructionOffset), clazz.getName(), method.getName(clazz), method.getDescriptor(clazz));
+        this.clazz = clazz;
+        this.method = method;
+        this.instruction = instruction;
+        this.instructionOffset = instructionOffset;
+    }
+
+    public Clazz getClazz()
+    {
+        return clazz;
+    }
+
+    public Method getMethod()
+    {
+        return method;
+    }
+
+    public Instruction getInstruction()
+    {
+        return instruction;
+    }
+
+    public int getInstructionOffset()
+    {
+        return instructionOffset;
+    }
+}

--- a/base/src/main/java/proguard/evaluation/PartialEvaluator.java
+++ b/base/src/main/java/proguard/evaluation/PartialEvaluator.java
@@ -40,7 +40,7 @@ import proguard.classfile.util.BranchTargetFinder;
 import proguard.classfile.visitor.ExceptionHandlerFilter;
 import proguard.evaluation.exception.EmptyCodeAttributeException;
 import proguard.evaluation.exception.ExcessiveComplexityException;
-import proguard.evaluation.exception.InstructionExceptionFormatter;
+import proguard.exception.InstructionExceptionFormatter;
 import proguard.evaluation.exception.StackGeneralizationException;
 import proguard.evaluation.exception.VariablesGeneralizationException;
 import proguard.evaluation.util.DebugPrinter;

--- a/base/src/main/java/proguard/exception/ErrorId.java
+++ b/base/src/main/java/proguard/exception/ErrorId.java
@@ -40,6 +40,7 @@ public final class ErrorId
     public static int VARIABLE_GENERALIZATION           = 1_010;
     public static int STACK_GENERALIZATION              = 1_011;
     public static int ARRAY_STORE_TYPE_EXCEPTION        = 1_012;
+    public static int NEGATIVE_STACK_SIZE               = 2_000;
 
     /**
      * Private constructor to prevent instantiation of the class.

--- a/base/src/main/java/proguard/exception/InstructionExceptionFormatter.java
+++ b/base/src/main/java/proguard/exception/InstructionExceptionFormatter.java
@@ -1,4 +1,22 @@
-package proguard.evaluation.exception;
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2023 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proguard.exception;
 
 import org.apache.logging.log4j.Logger;
 import proguard.classfile.Clazz;
@@ -12,7 +30,7 @@ import proguard.util.CircularIntBuffer;
 
 /**
  * This class is used to format an exception with the previous instructions.
- * It is used by the {@link proguard.evaluation.PartialEvaluator} to print the
+ * It is used by the {@link proguard.evaluation.PartialEvaluator} and {@link proguard.classfile.attribute.visitor.StackSizeComputer} to print the
  * erroneous instruction and any previous bytecode instructions and the next one to give some context.
  */
 public class InstructionExceptionFormatter
@@ -40,6 +58,11 @@ public class InstructionExceptionFormatter
     public void registerInstructionOffset(int offset)
     {
         offsetBuffer.push(offset);
+    }
+
+    public void printException(ProguardCoreException exception)
+    {
+        printException(exception, null, null);
     }
 
     public void printException(ProguardCoreException exception, TracedVariables variables, TracedStack stack)
@@ -131,12 +154,20 @@ public class InstructionExceptionFormatter
         }
 
         // Print stack and variables
-        messageBuilder
-                .append("Variables: ")
-                .append(variables)
-                .append("\nStack: ")
-                .append(stack)
-                .append("\n");
+        if (variables != null) {
+            messageBuilder
+                    .append("Variables: ")
+                    .append(variables)
+                    .append("\n");
+        }
+
+        if (stack != null)
+        {
+            messageBuilder
+                    .append("Stack: ")
+                    .append(stack)
+                    .append("\n");
+        }
 
         logger.error(messageBuilder.toString());
 

--- a/base/src/test/kotlin/proguard/classfile/attribute/visitor/StackSizeComputerTest.kt
+++ b/base/src/test/kotlin/proguard/classfile/attribute/visitor/StackSizeComputerTest.kt
@@ -1,0 +1,52 @@
+package proguard.classfile.attribute.visitor
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FreeSpec
+import proguard.analysis.buildClass
+import proguard.classfile.AccessConstants
+import proguard.classfile.exception.NegativeStackSizeException
+
+class StackSizeComputerTest: FreeSpec({
+    "Throws exceptions" - {
+        StackSizeComputer.prettyInstructionBuffered = 7
+        "Stack size becomes negative" {
+            // The stack size will be negative in this snippet, because we used the wrong type operation
+            shouldThrow<NegativeStackSizeException> {
+                buildClass()
+                    .addMethod(AccessConstants.PUBLIC, "test", "()J", 50) { code ->
+                        code
+                            .iconst_3()
+                            .iconst_1()
+                            .lsub()
+                            .lreturn()
+                    }
+                    .programClass
+            }
+        }
+
+        "Swap operation on a too small stack" {
+            shouldThrow<NegativeStackSizeException> {
+                buildClass()
+                    .addMethod(AccessConstants.PUBLIC, "test", "()V", 50) { code ->
+                        code
+                            .iconst_5()
+                            .swap()
+                            .return_()
+                    }
+                    .programClass
+            }
+        }
+
+        "Dup operation on an empty stack" {
+            shouldThrow<NegativeStackSizeException> {
+                buildClass()
+                    .addMethod(AccessConstants.PUBLIC, "test", "()V", 50) { code ->
+                        code
+                            .dup()
+                            .return_()
+                    }
+                    .programClass
+            }
+        }
+    }
+})

--- a/base/src/test/kotlin/proguard/classfile/attribute/visitor/StackSizeComputerTest.kt
+++ b/base/src/test/kotlin/proguard/classfile/attribute/visitor/StackSizeComputerTest.kt
@@ -6,7 +6,7 @@ import proguard.analysis.buildClass
 import proguard.classfile.AccessConstants
 import proguard.classfile.exception.NegativeStackSizeException
 
-class StackSizeComputerTest: FreeSpec({
+class StackSizeComputerTest : FreeSpec({
     "Throws exceptions" - {
         StackSizeComputer.prettyInstructionBuffered = 7
         "Stack size becomes negative" {


### PR DESCRIPTION
As mentioned by @Mouwrice in @96, we could still extract a prettier exception format for the negative stack size.

![image](https://github.com/Guardsquare/proguard-core/assets/35114273/a251bca8-becb-44ba-96a1-b0451e95a3d1)
