### PR TITLE
Don't drop Record attribute for records with no components

### DIFF
--- a/base/src/main/java/proguard/classfile/attribute/visitor/NonEmptyAttributeFilter.java
+++ b/base/src/main/java/proguard/classfile/attribute/visitor/NonEmptyAttributeFilter.java
@@ -85,10 +85,7 @@ implements   AttributeVisitor
 
     public void visitRecordAttribute(Clazz clazz, RecordAttribute recordAttribute)
     {
-        if (recordAttribute.u2componentsCount > 0)
-        {
-            attributeVisitor.visitRecordAttribute(clazz, recordAttribute);
-        }
+        attributeVisitor.visitRecordAttribute(clazz, recordAttribute);
     }
 
 


### PR DESCRIPTION
Although they are [not strictly required by the JVM specification](https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-4.html#jvms-4.7), `Record` attributes are usually preserved by Proguard. When determining which attributes are used, `NonEmptyAttributeFilter` is chained with `AttributeUsageMarker` in order to mark all non-empty attributes as used. This includes `Record` attributes: however, they are additionally filtered based on the number of components of the record. This means that any record with no components will not have its `Record` attribute marked as used, and it will be dropped. 

This is a fairly low-impact issue; it seems inconsistent and unexpected, though I can see that it may also be intentional.

Related issue: [MC-264564](https://bugs.mojang.com/browse/MC-264564).

Thanks!