### PR TITLE
Support a pass through mode for modification time of DataEntries in ZipWriter

### DIFF
--- a/base/src/main/java/proguard/io/ClassPathDataEntry.java
+++ b/base/src/main/java/proguard/io/ClassPathDataEntry.java
@@ -81,6 +81,13 @@ public class ClassPathDataEntry implements DataEntry
 
 
     @Override
+    public long getModificationTime()
+    {
+        return -1;
+    }
+
+
+    @Override
     public boolean isDirectory()
     {
         return false;

--- a/base/src/main/java/proguard/io/DataEntry.java
+++ b/base/src/main/java/proguard/io/DataEntry.java
@@ -45,6 +45,11 @@ public interface DataEntry
      */
     public long getSize();
 
+    /**
+     * Returns the modification time of this data entry in milliseconds,
+     * since the epoch (1970-01-01T00:00:00Z), or -1 if unknown.
+     */
+    public long getModificationTime();
 
     /**
      * Returns whether the data entry represents a directory.

--- a/base/src/main/java/proguard/io/DummyDataEntry.java
+++ b/base/src/main/java/proguard/io/DummyDataEntry.java
@@ -74,6 +74,13 @@ public class DummyDataEntry implements DataEntry
 
 
     @Override
+    public long getModificationTime()
+    {
+        return -1;
+    }
+
+
+    @Override
     public boolean isDirectory()
     {
         return isDirectory;

--- a/base/src/main/java/proguard/io/FileDataEntry.java
+++ b/base/src/main/java/proguard/io/FileDataEntry.java
@@ -108,6 +108,13 @@ public class FileDataEntry implements DataEntry
 
 
     @Override
+    public long getModificationTime()
+    {
+        return file.lastModified();
+    }
+
+
+    @Override
     public boolean isDirectory()
     {
         return file.isDirectory();

--- a/base/src/main/java/proguard/io/NamedDataEntry.java
+++ b/base/src/main/java/proguard/io/NamedDataEntry.java
@@ -19,6 +19,7 @@ package proguard.io;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
 
 /**
  * This <code>DataEntry</code> represents a named output entry with a parent.
@@ -65,6 +66,13 @@ public class NamedDataEntry implements DataEntry
     public long getSize()
     {
         return size;
+    }
+
+
+    @Override
+    public long getModificationTime()
+    {
+        return -1;
     }
 
 

--- a/base/src/main/java/proguard/io/StreamingDataEntry.java
+++ b/base/src/main/java/proguard/io/StreamingDataEntry.java
@@ -64,6 +64,13 @@ public class StreamingDataEntry
 
 
     @Override
+    public long getModificationTime()
+    {
+        return -1;
+    }
+
+
+    @Override
     public boolean isDirectory()
     {
         return false;

--- a/base/src/main/java/proguard/io/WrappedDataEntry.java
+++ b/base/src/main/java/proguard/io/WrappedDataEntry.java
@@ -64,6 +64,13 @@ public class WrappedDataEntry implements DataEntry
 
 
     @Override
+    public long getModificationTime()
+    {
+        return wrappedEntry.getModificationTime();
+    }
+
+
+    @Override
     public boolean isDirectory()
     {
         return wrappedEntry.isDirectory();

--- a/base/src/main/java/proguard/io/ZipDataEntry.java
+++ b/base/src/main/java/proguard/io/ZipDataEntry.java
@@ -79,6 +79,12 @@ public class ZipDataEntry implements DataEntry
 
 
     @Override
+    public long getModificationTime()
+    {
+        return zipEntry.getLastModifiedTime().toMillis();
+    }
+
+    @Override
     public boolean isDirectory()
     {
         return zipEntry.isDirectory();

--- a/base/src/main/java/proguard/io/ZipFileDataEntry.java
+++ b/base/src/main/java/proguard/io/ZipFileDataEntry.java
@@ -80,6 +80,13 @@ public class ZipFileDataEntry implements DataEntry
 
 
     @Override
+    public long getModificationTime()
+    {
+        return zipEntry.getLastModifiedTime().toMillis();
+    }
+
+
+    @Override
     public boolean isDirectory()
     {
         return zipEntry.isDirectory();

--- a/examples/src/main/java/proguard/examples/JarSigner.java
+++ b/examples/src/main/java/proguard/examples/JarSigner.java
@@ -1,0 +1,132 @@
+package proguard.examples;
+
+import proguard.io.*;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableEntryException;
+import java.security.cert.CertificateException;
+
+/**
+ * This sample application illustrates how to sign jars with the ProGuardCORE API.
+ * <p>
+ * Usage:
+ *     java proguard.examples.JarSigner -ks <keystore> -kspass <password> -key <alias> -keypass <password> input.jar output.jar
+ */
+public class JarSigner
+{
+    private static final String KEYSTORE          = "-ks";
+    private static final String KEYSTORE_PASSWORD = "-kspass";
+    private static final String KEY_ALIAS         = "-key";
+    private static final String KEY_PASSWORD      = "-keypass";
+
+
+    private static void usage() {
+        System.err.println("usage: java proguard.examples.JarSigner " +
+                "-ks <keystore> -kspass <password> -key <alias> " +
+                "-keypass <password> input.jar output.jar");
+        System.exit(1);
+    }
+
+    private static KeyStore.PrivateKeyEntry getPrivateKeyEntry(String keyStoreFileName, String keyStorePassword, String keyAlias, String keyPassword) {
+        try (FileInputStream keyStoreInputStream = new FileInputStream(keyStoreFileName)) {
+            // Get the private key from the key store.
+            KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            keyStore.load(keyStoreInputStream, keyStorePassword.toCharArray());
+
+            KeyStore.ProtectionParameter protectionParameter = new KeyStore.PasswordProtection(keyPassword.toCharArray());
+
+            return (KeyStore.PrivateKeyEntry)keyStore.getEntry(keyAlias, protectionParameter);
+        } catch (IOException | KeyStoreException | NoSuchAlgorithmException | CertificateException | UnrecoverableEntryException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public static void main(String[] args)
+    {
+        if (args.length != 10) {
+            usage();
+        }
+
+        String keyStoreFileName = null;
+        String keyStorePassword = null;
+        String keyAlias         = null;
+        String keyPassword      = null;
+
+        String inputJarFileName  = null;
+        String outputJarFileName = null;
+
+        int argIndex = 0;
+        while (argIndex < args.length) {
+            switch (args[argIndex]) {
+                case KEYSTORE:
+                    keyStoreFileName = args[++argIndex];
+                    break;
+
+                case KEYSTORE_PASSWORD:
+                    keyStorePassword = args[++argIndex];
+                    break;
+
+                case KEY_ALIAS:
+                    keyAlias = args[++argIndex];
+                    break;
+
+                case KEY_PASSWORD:
+                    keyPassword = args[++argIndex];
+                    break;
+
+                default:
+                    if (inputJarFileName == null) {
+                        inputJarFileName = args[argIndex];
+                    } else {
+                        outputJarFileName = args[argIndex];
+                    }
+                    break;
+            }
+
+            argIndex++;
+        }
+
+        if (keyStoreFileName  == null ||
+            keyStorePassword  == null ||
+            keyAlias          == null ||
+            keyPassword       == null ||
+            inputJarFileName  == null ||
+            outputJarFileName == null) {
+            usage();
+        }
+
+        try
+        {
+            KeyStore.PrivateKeyEntry privateKeyEntry =
+                getPrivateKeyEntry(keyStoreFileName, keyStorePassword, keyAlias, keyPassword);
+
+            // We'll write the output to a jar file.
+            JarWriter jarWriter =
+                new SignedJarWriter(privateKeyEntry,
+                new ZipWriter(
+                new FixedFileWriter(
+                new File(outputJarFileName))));
+
+            // Parse and push all classes from the input jar.
+            DataEntrySource source =
+                new FileSource(
+                new File(inputJarFileName));
+
+            source.pumpDataEntries(
+                new JarReader(
+                new DataEntryCopier(jarWriter)
+                ));
+
+            jarWriter.close();
+        }
+        catch (IOException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Right now, the ZipWriter by default will set the modification time of any written DataEntry to the specified modificationTime that has been passed as constructor argument.

However for certain use-cases it would be desirable to retain the original modification time of DataEntries that are being processed.

This PR adds support for retaining the modification time if it is available. The behavior can be controlled by setting the modification time of a ZipWriter to -1, which will instruct the ZipWriter to use the modification time of each DataEntry if available, otherwise resort to Instant.now() which is a reasonable default imho.

The PR also adds a JarSigner example to showcase how proguard-core can be used as a replacement for the jarsigner tool.

In a subsequent PR I will also add support for timestamping in the SignedJarWriter.

Please let me know if a change like that would be of interest for the library.