### PR TITLE
Refactor ExecutingInvocationUnit to use customizable executors

### DIFF
--- a/base/src/main/java/proguard/analysis/cpa/jvm/domain/value/JvmValueTransferRelation.java
+++ b/base/src/main/java/proguard/analysis/cpa/jvm/domain/value/JvmValueTransferRelation.java
@@ -135,7 +135,7 @@ public class JvmValueTransferRelation extends JvmTransferRelation<ValueAbstractS
       String internalReturnClassName = ClassUtil.internalClassNameFromType(returnType);
       if (returnType != null
           && internalReturnClassName != null
-          && executingInvocationUnit.isSupportedClass(internalReturnClassName)) {
+          && executingInvocationUnit.isSupportedMethodCall(internalReturnClassName, null)) {
         // we can at most know the return type
         pushReturnTypedValue(state, operands, (ConcreteCall) call, returnType);
         return;

--- a/base/src/main/java/proguard/analysis/cpa/jvm/domain/value/JvmValueTransferRelation.java
+++ b/base/src/main/java/proguard/analysis/cpa/jvm/domain/value/JvmValueTransferRelation.java
@@ -7,6 +7,8 @@ import static proguard.classfile.util.ClassUtil.isInternalCategory2Type;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Deque;
+import java.util.LinkedList;
 import java.util.List;
 import proguard.analysis.cpa.defaults.StackAbstractState;
 import proguard.analysis.cpa.interfaces.AbstractState;
@@ -121,6 +123,26 @@ public class JvmValueTransferRelation extends JvmTransferRelation<ValueAbstractS
   }
 
   @Override
+  protected void processCall(JvmAbstractState<ValueAbstractState> state, Call call) {
+    Deque<ValueAbstractState> operands = new LinkedList<>();
+    if (call.getTarget().descriptor.argumentTypes != null) {
+      List<String> argumentTypes = call.getTarget().descriptor.argumentTypes;
+      for (int i = argumentTypes.size() - 1; i >= 0; i--) {
+        boolean isCategory2 = ClassUtil.isInternalCategory2Type(argumentTypes.get(i));
+        operands.offerFirst(state.pop());
+        if (isCategory2) {
+          // ExecutingInvocationUnit expects a single parameter for category 2 values
+          state.pop();
+        }
+      }
+    }
+    if (!call.isStatic()) {
+      operands.offerFirst(state.pop());
+    }
+    invokeMethod(state, call, (List<ValueAbstractState>) operands);
+  }
+
+  @Override
   public void invokeMethod(
       JvmAbstractState<ValueAbstractState> state, Call call, List<ValueAbstractState> operands) {
     if (call instanceof ConcreteCall) {
@@ -151,8 +173,15 @@ public class JvmValueTransferRelation extends JvmTransferRelation<ValueAbstractS
       List<ValueAbstractState> operands) {
     Clazz targetClass = call.getTargetClass();
     Method targetMethod = call.getTargetMethod();
+
     Value[] operandsArray =
         operands.stream().map(ValueAbstractState::getValue).toArray(Value[]::new);
+
+    if (operandsArray.length
+        != ClassUtil.internalMethodParameterCount(
+            call.getTarget().descriptor.toString(), call.isStatic())) {
+      throw new IllegalStateException("Unexpected number of parameters");
+    }
 
     Value result = executingInvocationUnit.executeMethod(call, operandsArray);
     String returnType = internalMethodReturnType(targetMethod.getDescriptor(targetClass));

--- a/base/src/main/java/proguard/classfile/JavaConstants.java
+++ b/base/src/main/java/proguard/classfile/JavaConstants.java
@@ -26,6 +26,14 @@ package proguard.classfile;
 public class JavaConstants {
   public static final String JAVA_FILE_EXTENSION = ".java";
 
+  public static final String TYPE_JAVA_LANG_BOOLEAN = "java.lang.Boolean";
+  public static final String TYPE_JAVA_LANG_INTEGER = "java.lang.Integer";
+  public static final String TYPE_JAVA_LANG_LONG = "java.lang.Long";
+  public static final String TYPE_JAVA_LANG_CHARACTER = "java.lang.Character";
+  public static final String TYPE_JAVA_LANG_BYTE = "java.lang.Byte";
+  public static final String TYPE_JAVA_LANG_SHORT = "java.lang.Short";
+  public static final String TYPE_JAVA_LANG_FLOAT = "java.lang.Float";
+  public static final String TYPE_JAVA_LANG_DOUBLE = "java.lang.Double";
   public static final String TYPE_JAVA_LANG_OBJECT = "java.lang.Object";
   public static final String TYPE_JAVA_LANG_STRING = "java.lang.String";
   public static final String TYPE_JAVA_LANG_CLASS = "java.lang.Class";

--- a/base/src/main/java/proguard/evaluation/ExecutingInvocationUnit.java
+++ b/base/src/main/java/proguard/evaluation/ExecutingInvocationUnit.java
@@ -322,14 +322,10 @@ public class ExecutingInvocationUnit extends BasicInvocationUnit {
             .map(result -> createResultValue(methodInfo, instanceId, result, returnsOwnInstance))
             .orElse(createFallbackResultValue(methodInfo, returnsOwnInstance, instanceId));
 
-    if (parameters != null
-        && !methodInfo.isStatic()
-        && instanceValue != null
-        && resultValue != null
-        && resultValue.isParticular()) {
+    if (parameters != null && !methodInfo.isStatic() && instanceValue != null) {
       Value oldInstanceValue = parameters[0];
       Value updatedInstanceValue =
-          returnsOwnInstance
+          returnsOwnInstance && resultValue != null && resultValue.isParticular()
               // if the method returned its instance there is no need to create a new value
               ? resultValue
               : (!Objects.equals(oldInstanceValue.referenceValue().value(), callingInstance))

--- a/base/src/main/java/proguard/evaluation/ExecutingInvocationUnit.java
+++ b/base/src/main/java/proguard/evaluation/ExecutingInvocationUnit.java
@@ -125,7 +125,7 @@ public class ExecutingInvocationUnit extends BasicInvocationUnit {
   /** Builds an {@link ExecutingInvocationUnit}. */
   public static class Builder {
     protected boolean enableSameInstanceIdApproximation = false;
-    protected boolean addDefaultStringReflectionExecutor = true;
+    protected boolean useDefaultStringReflectionExecutor = true;
     protected List<Executor> registeredExecutors = new ArrayList<>();
 
     /**
@@ -146,7 +146,7 @@ public class ExecutingInvocationUnit extends BasicInvocationUnit {
      *
      * <p>N.B.: If a method is supported by different executors the first one added gets priority.
      * If {@link
-     * proguard.evaluation.ExecutingInvocationUnit.Builder#setAddDefaultStringReflectionExecutor(boolean)}
+     * proguard.evaluation.ExecutingInvocationUnit.Builder#useDefaultStringReflectionExecutor(boolean)}
      * is not set to <code>false</code> the default {@link StringReflectionExecutor} has the highest
      * priority.
      *
@@ -163,7 +163,7 @@ public class ExecutingInvocationUnit extends BasicInvocationUnit {
      *
      * <p>N.B.: If a method is supported by different executors the first one added gets priority.
      * If {@link
-     * proguard.evaluation.ExecutingInvocationUnit.Builder#setAddDefaultStringReflectionExecutor(boolean)}
+     * proguard.evaluation.ExecutingInvocationUnit.Builder#useDefaultStringReflectionExecutor(boolean)}
      * is not set to <code>false</code> the default {@link StringReflectionExecutor} has the highest
      * priority.
      *
@@ -178,12 +178,11 @@ public class ExecutingInvocationUnit extends BasicInvocationUnit {
      * Set this flag to false if the {@link ExecutingInvocationUnit} should not use {@link
      * StringReflectionExecutor} by default.
      *
-     * @param addDefaultStringReflectionExecutor whether a default {@link StringReflectionExecutor}
+     * @param useDefaultStringReflectionExecutor whether a default {@link StringReflectionExecutor}
      *     should be used.
      */
-    public Builder setAddDefaultStringReflectionExecutor(
-        boolean addDefaultStringReflectionExecutor) {
-      this.addDefaultStringReflectionExecutor = addDefaultStringReflectionExecutor;
+    public Builder useDefaultStringReflectionExecutor(boolean useDefaultStringReflectionExecutor) {
+      this.useDefaultStringReflectionExecutor = useDefaultStringReflectionExecutor;
       return this;
     }
 
@@ -194,7 +193,7 @@ public class ExecutingInvocationUnit extends BasicInvocationUnit {
      * @return The built {@link ExecutingInvocationUnit}
      */
     public ExecutingInvocationUnit build(ValueFactory valueFactory) {
-      if (addDefaultStringReflectionExecutor)
+      if (useDefaultStringReflectionExecutor)
         registeredExecutors.add(0, new StringReflectionExecutor());
       return new ExecutingInvocationUnit(
           valueFactory, enableSameInstanceIdApproximation, registeredExecutors);

--- a/base/src/main/java/proguard/evaluation/ExecutingInvocationUnit.java
+++ b/base/src/main/java/proguard/evaluation/ExecutingInvocationUnit.java
@@ -20,10 +20,6 @@ package proguard.evaluation;
 
 import static proguard.classfile.AccessConstants.FINAL;
 import static proguard.classfile.AccessConstants.STATIC;
-import static proguard.classfile.ClassConstants.METHOD_NAME_INIT;
-import static proguard.classfile.ClassConstants.NAME_JAVA_LANG_STRING;
-import static proguard.classfile.ClassConstants.NAME_JAVA_LANG_STRING_BUFFER;
-import static proguard.classfile.ClassConstants.NAME_JAVA_LANG_STRING_BUILDER;
 import static proguard.classfile.ClassConstants.TYPE_JAVA_LANG_STRING;
 import static proguard.classfile.TypeConstants.BOOLEAN;
 import static proguard.classfile.TypeConstants.BYTE;
@@ -34,32 +30,25 @@ import static proguard.classfile.TypeConstants.INT;
 import static proguard.classfile.TypeConstants.LONG;
 import static proguard.classfile.TypeConstants.SHORT;
 import static proguard.classfile.TypeConstants.VOID;
-import static proguard.classfile.util.ClassUtil.externalClassName;
 import static proguard.classfile.util.ClassUtil.isInternalPrimitiveType;
 import static proguard.classfile.util.ClassUtil.isNullOrFinal;
-import static proguard.evaluation.value.BasicValueFactory.UNKNOWN_VALUE;
-import static proguard.evaluation.value.ReflectiveMethodCallUtil.callMethod;
 
 import java.lang.reflect.Array;
-import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
-import java.util.function.BiFunction;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
-import proguard.analysis.datastructure.callgraph.Call;
 import proguard.analysis.datastructure.callgraph.ConcreteCall;
 import proguard.classfile.Clazz;
 import proguard.classfile.Field;
 import proguard.classfile.Member;
 import proguard.classfile.Method;
+import proguard.classfile.MethodDescriptor;
+import proguard.classfile.MethodSignature;
 import proguard.classfile.ProgramClass;
 import proguard.classfile.ProgramField;
 import proguard.classfile.attribute.Attribute;
@@ -77,137 +66,147 @@ import proguard.classfile.constant.visitor.ConstantVisitor;
 import proguard.classfile.util.ClassUtil;
 import proguard.classfile.visitor.MemberAccessFilter;
 import proguard.classfile.visitor.MemberVisitor;
-import proguard.classfile.visitor.ReturnClassExtractor;
-import proguard.evaluation.value.IdentifiedReferenceValue;
-import proguard.evaluation.value.ParticularReferenceValue;
+import proguard.evaluation.executor.Executor;
+import proguard.evaluation.executor.MethodExecutionInfo;
+import proguard.evaluation.executor.StringReflectionExecutor;
 import proguard.evaluation.value.ReferenceValue;
-import proguard.evaluation.value.ReflectiveMethodCallUtil;
 import proguard.evaluation.value.Value;
 import proguard.evaluation.value.ValueFactory;
 
 /**
- * This {@link ExecutingInvocationUnit} reflectively executes the method calls it visits on a given
- * {@link ParticularReferenceValue}.
+ * This {@link InvocationUnit} is capable of executing the invoked methods with particular values as
+ * parameters.
  *
- * <p>After the (reflective) execution of method, it also takes care to replace values on
- * stack/variables if needed. This needs to be done, as the PartialEvaluator treats all entries on
- * stack/variables as immutable, and assumes that every change creates a new object.
+ * <p>If a method has a return value, this value is determined and supplied as a particular {@link
+ * Value}. Methods that operate on an instance are able to modify the calling instance. For such
+ * methods, references in the stack and variables to that instance are replaced with the modified
+ * one. This also applies to constructors.
  *
- * <p>Before a method call, the stack/variables can contain multiple references to the same object.
- * If the method call then creates a new Variable (representing an updated object), we need to
- * update all references to this new Variable.
+ * <p>This class is responsible for creating the final particular {@link Value}s for methods that
+ * were handled without errors and creating fallback values in case the method could not be handled.
+ * It also performs the action of replacing references of instances that changed in the stack and
+ * variables if needed. This is however limited as we only update the instance if it was modified
+ * and ignores all other parameters which might have changed too.
  *
- * <p>There are some methods which always return a new object when the method is actually executed
- * in the JVM (e.g. StringBuilder.toString). For such method calls, we never update the
- * stack/variables (Denylist, Case 1)
- *
- * <p>For certain methods (e.g. the Constructor), we always need to replace the value on
- * stack/variables (Allowlist, Case 3)
- *
- * <p>In all other cases, we assume the underlying object was changed if the returned value is of
- * the same type as the called upon instance. This is an approximation, which works well for
- * Strings, StringBuffer, StringBuilder (Approximation, Case 3)
- *
- * @author Dennis Titze
+ * <p>An {@link ExecutingInvocationUnit} delegates the acquisition of method results and certain
+ * other decisions (e.g. whether replacing references in the stack and variables is needed) to its
+ * {@link Executor}s. Per default, an instance of this class will have access to a {@link
+ * StringReflectionExecutor} that handles methods of {@link String}, {@link StringBuilder} and
+ * {@link StringBuffer}. The {@link Builder}, allows for disabling the default {@link
+ * StringReflectionExecutor} and adding other {@link Executor}s.
  */
 public class ExecutingInvocationUnit extends BasicInvocationUnit {
-
-  public static boolean DEBUG = System.getProperty("eiu") != null;
-
-  // Used to store the parameters for one method call.
-  private static final Logger log = LogManager.getLogger(ExecutingInvocationUnit.class);
   @Nullable private Value[] parameters;
-  private final Map<String, Set<String>> alwaysReturnsNewInstance;
-  private final Map<String, Set<String>> alwaysModifiesInstance;
   private final boolean enableSameInstanceIdApproximation;
+  private final List<Executor> registeredExecutors;
 
-  /**
-   * Creates an invocation unit resolving the methods from the specified classes via reflection.
-   *
-   * @param valueFactory a value factory
-   * @param alwaysReturnsNewInstance a mapping from class name to method name of methods that the
-   *     invocation unit will assume to always return a new reference
-   * @param alwaysModifiesInstance a mapping from class name to method name of methods that the
-   *     invocation unit will assume to modify the calling instance
-   * @param enableSameInstanceIdApproximation whether the invocation unit will assume for classes
-   *     not supported for execution that they might return the same reference of the calling
-   *     instance if their types match
-   */
+  // Lazily initialized lookup from method signatures to their responsible executor.
+  private final Map<MethodSignature, Executor> responsibleExecutor = new HashMap<>();
+
+  /** Creates an {@link ExecutingInvocationUnit}. */
   protected ExecutingInvocationUnit(
       ValueFactory valueFactory,
-      Map<String, Set<String>> alwaysReturnsNewInstance,
-      Map<String, Set<String>> alwaysModifiesInstance,
-      boolean enableSameInstanceIdApproximation) {
+      boolean enableSameInstanceIdApproximation,
+      List<Executor> registeredExecutors) {
     super(valueFactory);
     this.enableSameInstanceIdApproximation = enableSameInstanceIdApproximation;
-    this.alwaysReturnsNewInstance = alwaysReturnsNewInstance;
-    this.alwaysModifiesInstance = alwaysModifiesInstance;
+    this.registeredExecutors = registeredExecutors;
   }
 
+  /** Deprecated constructor, use {@link ExecutingInvocationUnit.Builder}. */
   @Deprecated
-  /** Deprecated constructor, use {@link proguard.evaluation.ExecutingInvocationUnit.Builder}. */
   public ExecutingInvocationUnit(ValueFactory valueFactory) {
-    this(valueFactory, Builder.alwaysReturnsNewInstanceDefault(), Collections.emptyMap(), false);
+    this(
+        valueFactory,
+        false,
+        new ArrayList<>(Collections.singletonList(new StringReflectionExecutor())));
   }
 
   /** Builds an {@link ExecutingInvocationUnit}. */
   public static class Builder {
-
-    protected Map<String, Set<String>> alwaysReturnsNewInstance = alwaysReturnsNewInstanceDefault();
-    protected Map<String, Set<String>> alwaysModifiesInstance = Collections.emptyMap();
     protected boolean enableSameInstanceIdApproximation = false;
+    protected boolean addDefaultStringReflectionExecutor = true;
+    protected List<Executor> registeredExecutors = new ArrayList<>();
 
     /**
-     * @param valueFactory a value factory
-     * @return the build {@link ExecutingInvocationUnit}
-     */
-    public ExecutingInvocationUnit build(ValueFactory valueFactory) {
-      return new ExecutingInvocationUnit(
-          valueFactory,
-          alwaysReturnsNewInstance,
-          alwaysModifiesInstance,
-          enableSameInstanceIdApproximation);
-    }
-
-    /**
-     * @param alwaysReturnsNewInstance a mapping from class name to method name of methods that the
-     *     invocation unit will assume to always return a new reference
-     * @return the {@link Builder}
-     */
-    public Builder setAlwaysReturnsNewInstance(Map<String, Set<String>> alwaysReturnsNewInstance) {
-      this.alwaysReturnsNewInstance = alwaysReturnsNewInstance;
-      return this;
-    }
-
-    /**
-     * @param alwaysModifiesInstance a mapping from class name to method name of methods that the
-     *     invocation unit will assume to modify the calling instance
-     * @return the {@link Builder}
-     */
-    public Builder setAlwaysModifiesInstance(Map<String, Set<String>> alwaysModifiesInstance) {
-      this.alwaysModifiesInstance = alwaysModifiesInstance;
-      return this;
-    }
-
-    /**
-     * @param enableSameInstanceIdApproximation whether the invocation unit will assume for classes
-     *     not supported for execution that they might return the same reference of the calling
-     *     instance if their types match
-     * @return the {@link Builder}
+     * For methods that are not supported by any executor, decide, whether a method with matching
+     * return and instance types should be treated as a method which returns its instance. In such a
+     * case, setting this flag to true will result in no new ID being created for the return value.
+     *
+     * @param enableSameInstanceIdApproximation whether the approximation should be enabled.
      */
     public Builder setEnableSameInstanceIdApproximation(boolean enableSameInstanceIdApproximation) {
       this.enableSameInstanceIdApproximation = enableSameInstanceIdApproximation;
       return this;
     }
 
-    private static Map<String, Set<String>> alwaysReturnsNewInstanceDefault() {
-      return new HashMap<String, Set<String>>() {
-        {
-          put(NAME_JAVA_LANG_STRING_BUILDER, Collections.singleton("toString"));
-          put(NAME_JAVA_LANG_STRING_BUFFER, Collections.singleton("toString"));
-          put(NAME_JAVA_LANG_STRING, Stream.of("toString", "valueOf").collect(Collectors.toSet()));
-        }
-      };
+    /**
+     * Add an {@link Executor} to be considered by the {@link ExecutingInvocationUnit} when trying
+     * to analyze a method call.
+     *
+     * <p>N.B.: If a method is supported by different executors the first one added gets priority.
+     * If {@link
+     * proguard.evaluation.ExecutingInvocationUnit.Builder#setAddDefaultStringReflectionExecutor(boolean)}
+     * is not set to <code>false</code> the default {@link StringReflectionExecutor} has the highest
+     * priority.
+     *
+     * @param executor The {@link Executor} to be added.
+     */
+    public Builder addExecutor(Executor executor) {
+      registeredExecutors.add(executor);
+      return this;
+    }
+
+    /**
+     * Add multiple {@link Executor}s to be considered by the {@link ExecutingInvocationUnit} when
+     * trying to analyze a method call.
+     *
+     * <p>N.B.: If a method is supported by different executors the first one added gets priority.
+     * If {@link
+     * proguard.evaluation.ExecutingInvocationUnit.Builder#setAddDefaultStringReflectionExecutor(boolean)}
+     * is not set to <code>false</code> the default {@link StringReflectionExecutor} has the highest
+     * priority.
+     *
+     * @param executors The {@link Executor}s to be added.
+     */
+    public Builder addExecutors(Executor... executors) {
+      registeredExecutors.addAll(Arrays.asList(executors));
+      return this;
+    }
+
+    /**
+     * Set this flag to false if the {@link ExecutingInvocationUnit} should not use {@link
+     * StringReflectionExecutor} by default.
+     *
+     * @param addDefaultStringReflectionExecutor whether a default {@link StringReflectionExecutor}
+     *     should be used.
+     */
+    public Builder setAddDefaultStringReflectionExecutor(
+        boolean addDefaultStringReflectionExecutor) {
+      this.addDefaultStringReflectionExecutor = addDefaultStringReflectionExecutor;
+      return this;
+    }
+
+    /**
+     * Build the {@link ExecutingInvocationUnit} defined by this builder instance.
+     *
+     * @param valueFactory The {@link ValueFactory} responsible for creating result values.
+     * @return The built {@link ExecutingInvocationUnit}
+     */
+    public ExecutingInvocationUnit build(ValueFactory valueFactory) {
+      if (addDefaultStringReflectionExecutor)
+        registeredExecutors.add(0, new StringReflectionExecutor());
+      return new ExecutingInvocationUnit(
+          valueFactory, enableSameInstanceIdApproximation, registeredExecutors);
+    }
+  }
+
+  @Override
+  public void visitAnyMethodrefConstant(Clazz clazz, AnyMethodrefConstant anyMethodrefConstant) {
+    try {
+      super.visitAnyMethodrefConstant(clazz, anyMethodrefConstant);
+    } finally {
+      this.parameters = null;
     }
   }
 
@@ -218,7 +217,6 @@ public class ExecutingInvocationUnit extends BasicInvocationUnit {
       Clazz clazz, AnyMethodrefConstant anyMethodrefConstant, int parameterIndex, Value value) {
     if (parameters == null) {
       // This is the first invocation of setMethodParameterValue for this method.
-      // Initialize array
       String type = anyMethodrefConstant.getType(clazz);
       int parameterCount = ClassUtil.internalMethodParameterCount(type, isStatic);
       parameters = new Value[parameterCount];
@@ -232,7 +230,7 @@ public class ExecutingInvocationUnit extends BasicInvocationUnit {
     // Only execute methods which have at least one parameter.
     // If the method is a static method, this means that at least one parameter is set,
     // if the method is an instance call, at least the instance needs to be set.
-    // Static calls without parameters will not be called, as the side-effects of those cannot
+    // Static calls without parameters will not be called, as the side effects of those cannot
     // currently be tracked.
     return parameters != null && parameters.length > 0;
   }
@@ -240,67 +238,332 @@ public class ExecutingInvocationUnit extends BasicInvocationUnit {
   @Override
   public Value getMethodReturnValue(
       Clazz clazz, AnyMethodrefConstant anyMethodrefConstant, String returnType) {
+    if (anyMethodrefConstant.referencedMethod == null || parameters == null) {
+      return super.getMethodReturnValue(clazz, anyMethodrefConstant, returnType);
+    }
 
-    String baseClassName = anyMethodrefConstant.getClassName(clazz);
-    Clazz referencedClass = getReferencedClass(anyMethodrefConstant, false);
+    MethodExecutionInfo methodInfo = new MethodExecutionInfo(anyMethodrefConstant, null);
 
-    if (!isSupportedMethodCall(baseClassName, anyMethodrefConstant.getName(clazz))) {
-      if (enableSameInstanceIdApproximation
-          && anyMethodrefConstant.referencedMethod != null
-          && !isInternalPrimitiveType(returnType)
-          && parameters != null
-          && parameters.length > 0
-          && parameters[0] instanceof IdentifiedReferenceValue
-          && returnsOwnInstance(
-              baseClassName,
-              anyMethodrefConstant.getName(clazz),
-              anyMethodrefConstant.referencedMethod.getDescriptor(
-                  anyMethodrefConstant.referencedClass),
-              (anyMethodrefConstant.referencedMethod.getAccessFlags() & STATIC) != 0,
-              returnType)) {
-        return valueFactory.createReferenceValueForId(
-            returnType,
-            referencedClass,
-            isNullOrFinal(referencedClass),
-            true,
-            ((IdentifiedReferenceValue) parameters[0]).id);
-      } else {
-        return valueFactory.createValue(
-            returnType, referencedClass, isNullOrFinal(referencedClass), true);
+    Executor executor = getResponsibleExecutor(methodInfo.getSignature());
+
+    Value result = executeMethod(executor, methodInfo, parameters);
+    // Only return the method result if the method is expected to return something.
+    return returnType.charAt(0) == VOID ? null : result;
+  }
+
+  /**
+   * Get the responsible {@link Executor} for a given class name and a method name. Cache previously
+   * determined executors.
+   *
+   * @param signature The method signature.
+   * @return The responsible executor.
+   */
+  private Executor getResponsibleExecutor(MethodSignature signature) {
+    return responsibleExecutor.computeIfAbsent(
+        signature,
+        sig ->
+            registeredExecutors.stream()
+                .filter(executor -> executor.isSupportedMethodCall(signature))
+                .findFirst()
+                .orElse(null));
+  }
+
+  /**
+   * Execute the method given by a {@link ConcreteCall}. See {@link
+   * ExecutingInvocationUnit#executeMethod(Executor, MethodExecutionInfo, Value...)}
+   *
+   * @param call The concrete call.
+   * @param parameters The calling parameters.
+   * @return The method result value.
+   */
+  public Value executeMethod(ConcreteCall call, Value... parameters) {
+    MethodExecutionInfo methodInfo = new MethodExecutionInfo(call);
+    Executor executor = getResponsibleExecutor(call.getTarget());
+    return executeMethod(executor, methodInfo, parameters);
+  }
+
+  /**
+   * Executes a method using a given {@link Executor}. Replace references of the instance in
+   * variables and stack if necessary. The return value represents the result of the executed
+   * method.
+   *
+   * @param executor The {@link Executor} which handles this method call.
+   * @param methodInfo Information about the method to execute.
+   * @param parameters The calling parameters.
+   * @return The method result value.
+   */
+  public Value executeMethod(
+      Executor executor, MethodExecutionInfo methodInfo, Value... parameters) {
+    ReferenceValue instanceValue = methodInfo.getInstanceValue(parameters).orElse(null);
+    Object instanceId = methodInfo.getObjectId(instanceValue).orElse(null);
+
+    boolean returnsSameTypeAsInstance = methodInfo.returnsSameTypeAsInstance(parameters);
+    boolean returnsOwnInstance;
+    if (executor == null) {
+      // The invocation unit is not able to execute the method. Calculate a fallback value.
+      returnsOwnInstance =
+          // If the method is a constructor, never create a new ID. Otherwise, only keep the ID if
+          // return and instance types match and the approximation is enabled.
+          methodInfo.isConstructor()
+              || enableSameInstanceIdApproximation && returnsSameTypeAsInstance;
+      return createFallbackResultValue(methodInfo, returnsOwnInstance, instanceId);
+    }
+
+    Object callingInstance = methodInfo.getCallingInstance(executor, parameters).orElse(null);
+
+    // The executor provides further information on whether a method returns its own instance.
+    returnsOwnInstance =
+        methodInfo.isConstructor()
+            || executor.returnsOwnInstance(methodInfo.getSignature(), returnsSameTypeAsInstance);
+
+    // The instantiated object for a constructor or the returned value otherwise
+    Value resultValue =
+        executor
+            .getMethodResult(methodInfo, instanceValue, callingInstance, parameters)
+            .map(result -> createResultValue(methodInfo, instanceId, result, returnsOwnInstance))
+            .orElse(createFallbackResultValue(methodInfo, returnsOwnInstance, instanceId));
+
+    if (parameters != null
+        && !methodInfo.isStatic()
+        && instanceValue != null
+        && resultValue != null
+        && resultValue.isParticular()) {
+      Value oldInstanceValue = parameters[0];
+      Value updatedInstanceValue =
+          returnsOwnInstance
+              // if the method returned its instance there is no need to create a new value
+              ? resultValue
+              : (!Objects.equals(oldInstanceValue.referenceValue().value(), callingInstance))
+                  // otherwise create a value with an updated object
+                  ? createUpdatedInstanceValue(instanceValue, instanceId, callingInstance)
+                  : null;
+
+      if (updatedInstanceValue != null) {
+        if (variables != null) {
+          replaceReferenceInVariables(updatedInstanceValue, oldInstanceValue, variables);
+        }
+        if (stack != null) {
+          replaceReferenceOnStack(updatedInstanceValue, oldInstanceValue, stack);
+        }
       }
     }
 
-    // TODO: Passing calling context parameters.
-    Value reflectedReturnValue =
-        executeMethod(
-            null,
-            null,
-            0,
-            anyMethodrefConstant.referencedClass,
-            anyMethodrefConstant.referencedMethod,
-            parameters);
-
-    updateStackAndVariables(clazz, anyMethodrefConstant, returnType, reflectedReturnValue);
-
-    // For a void-method, null is expected as return value.
-    return returnType.charAt(0) == VOID ? null : reflectedReturnValue;
+    return resultValue;
   }
 
-  @Override
-  public void visitAnyMethodrefConstant(Clazz clazz, AnyMethodrefConstant anyMethodrefConstant) {
-    try {
-      super.visitAnyMethodrefConstant(clazz, anyMethodrefConstant);
-    } finally {
-      this.parameters = null;
+  /**
+   * Create the result value of a method for a given method result object.
+   *
+   * @param methodInfo Information about the method.
+   * @param instanceId The ID of the instance.
+   * @param result The method result provided the {@link Executor}.
+   * @param returnsOwnInstance whether the method returns its own instance.
+   * @return The result value of the method.
+   */
+  private Value createResultValue(
+      MethodExecutionInfo methodInfo,
+      Object instanceId,
+      Object result,
+      boolean returnsOwnInstance) {
+    String resultType = methodInfo.getResultType();
+    if (isInternalPrimitiveType(resultType)) {
+      switch (resultType.charAt(0)) {
+        case BOOLEAN:
+          return valueFactory.createIntegerValue(((Boolean) result) ? 1 : 0);
+        case CHAR:
+          return valueFactory.createIntegerValue((Character) result);
+        case BYTE:
+          return valueFactory.createIntegerValue((Byte) result);
+        case SHORT:
+          return valueFactory.createIntegerValue((Short) result);
+        case INT:
+          return valueFactory.createIntegerValue((Integer) result);
+        case FLOAT:
+          return valueFactory.createFloatValue((Float) result);
+        case DOUBLE:
+          return valueFactory.createDoubleValue((Double) result);
+        case LONG:
+          return valueFactory.createLongValue((Long) result);
+      }
+      return null; // unreachable
+    } else if (resultType.charAt(0) == VOID) {
+      return null;
+    }
+
+    if (ClassUtil.internalArrayTypeDimensionCount(resultType) == 1
+        && isInternalPrimitiveType(ClassUtil.internalTypeFromArrayType(resultType))) {
+      return valueFactory.createArrayReferenceValue(
+          resultType, null, valueFactory.createIntegerValue(Array.getLength(result)), result);
+    }
+
+    boolean resultMayBeNull = result == null;
+    boolean resultMayBeExtension = !methodInfo.isConstructor();
+
+    if (instanceId != null && returnsOwnInstance) {
+      return valueFactory.createReferenceValueForId(
+          resultType,
+          methodInfo.getResultClass(),
+          resultMayBeExtension,
+          resultMayBeNull,
+          instanceId,
+          result);
+    }
+
+    return methodInfo
+        .getCaller()
+        .map(
+            caller ->
+                valueFactory.createReferenceValue(
+                    resultType,
+                    methodInfo.getResultClass(),
+                    resultMayBeExtension,
+                    resultMayBeNull,
+                    caller.clazz,
+                    (Method) caller.member,
+                    caller.offset,
+                    result))
+        .orElse(
+            valueFactory.createReferenceValue(
+                resultType,
+                methodInfo.getResultClass(),
+                resultMayBeExtension,
+                resultMayBeNull,
+                result));
+  }
+
+  /**
+   * Creates {@link Value} for the updated instance.
+   *
+   * @param instanceValue The old reference value of the instance.
+   * @param instanceId The id of the instance value.
+   * @param instance The updated object.
+   * @return the updated value.
+   */
+  private Value createUpdatedInstanceValue(
+      ReferenceValue instanceValue, Object instanceId, Object instance) {
+    return valueFactory.createReferenceValueForId(
+        instanceValue.internalType(),
+        instanceValue.getReferencedClass(),
+        instanceValue.mayBeExtension(),
+        instance == null,
+        instanceId,
+        instance);
+  }
+
+  /**
+   * Create a fallback result value for the method. Such a value is either used, when no matching
+   * executor was available for the method call or the matching executor failed to calculate a
+   * result.
+   *
+   * @param methodInfo Information about the method.
+   * @param returnsOwnInstance whether the method returns its own instance.
+   * @param instanceId The ID of the instance.
+   * @return The fallback result value.
+   */
+  private Value createFallbackResultValue(
+      MethodExecutionInfo methodInfo, boolean returnsOwnInstance, Object instanceId) {
+    String resultType = methodInfo.getResultType();
+    if (resultType.charAt(0) == VOID) {
+      return null;
+    }
+
+    if (isInternalPrimitiveType(resultType)) {
+      return valueFactory.createValue(resultType, null, false, false);
+    }
+
+    Clazz resultClass = methodInfo.getResultClass();
+    if (instanceId != null && returnsOwnInstance) {
+      return valueFactory.createReferenceValueForId(
+          resultType, resultClass, isNullOrFinal(resultClass), true, instanceId);
+    }
+
+    return valueFactory.createValue(resultType, resultClass, isNullOrFinal(resultClass), true);
+  }
+
+  /**
+   * Return whether the invocation unit is expected to handle the method call based on the class
+   * name and the method name.
+   *
+   * @param internalClassName The class name for the method.
+   * @param methodName The name of the method.
+   * @return whether the invocation unit is expected to handle the method call.
+   */
+  public boolean isSupportedMethodCall(String internalClassName, String methodName) {
+    return isSupportedMethodCall(
+        new MethodSignature(internalClassName, methodName, (MethodDescriptor) null));
+  }
+
+  public boolean isSupportedMethodCall(MethodSignature methodSignature) {
+    return getResponsibleExecutor(methodSignature) != null;
+  }
+
+  /**
+   * Determines whether the stack/variables need to be updated with the changed instance.
+   *
+   * @param clazz The class of the method.
+   * @param method The method.
+   * @param instance The instance of the method call.
+   * @return whether the method returns its own instance.
+   */
+  public boolean returnsOwnInstance(Clazz clazz, Method method, Value instance) {
+    if (!(instance instanceof ReferenceValue)) return false;
+
+    MethodExecutionInfo methodInfo = new MethodExecutionInfo(clazz, method, null);
+    if (methodInfo.isConstructor()) return true;
+
+    Executor executor = getResponsibleExecutor(methodInfo.getSignature());
+    boolean returnsSameTypeAsInstance = methodInfo.returnsSameTypeAsInstance(instance);
+    if (executor == null) {
+      return methodInfo.isConstructor()
+          || enableSameInstanceIdApproximation && methodInfo.returnsSameTypeAsInstance(parameters);
+    }
+
+    return executor.returnsOwnInstance(methodInfo.getSignature(), returnsSameTypeAsInstance);
+  }
+
+  /**
+   * Iterate the variables and replace all occurrences of oldValue with newValue.
+   *
+   * @param newValue the value which should be put in.
+   * @param oldValue the value to replace.
+   * @param variables the variables to look through.
+   */
+  private void replaceReferenceInVariables(Value newValue, Value oldValue, Variables variables) {
+    if (!oldValue.isSpecific() || variables == null) return;
+    // we need to replace all instances on the stack and in the vars with new instances now.
+    for (int i = 0; i < variables.size(); i++) {
+      Value value = variables.getValue(i);
+      if (Objects.equals(value, oldValue)) {
+        variables.store(i, newValue);
+      }
+      if (value != null && value.isCategory2()) i++;
+    }
+  }
+
+  /**
+   * Iterate the stack and replace all occurrences of oldValue with newValue.
+   *
+   * @param newValue the value which should be put in.
+   * @param oldValue the value to replace.
+   * @param stack the stack to look through.
+   */
+  private void replaceReferenceOnStack(Value newValue, Value oldValue, Stack stack) {
+    if (!oldValue.isSpecific()) return;
+    for (int i = 0; i < stack.size(); i++) {
+      Value top = stack.getTop(i);
+      if (Objects.equals(top, oldValue)) {
+        stack.setTop(i, newValue);
+      }
     }
   }
 
   @Override
   public Value getFieldValue(Clazz clazz, FieldrefConstant fieldrefConstant, String type) {
-    // get value from static final fields
+    // get values from static final fields
     FieldValueGetterVisitor constantVisitor = new FieldValueGetterVisitor();
     fieldrefConstant.referencedFieldAccept(
         new MemberAccessFilter(STATIC | FINAL, 0, constantVisitor));
+
     return constantVisitor.value == null
         ? super.getFieldValue(clazz, fieldrefConstant, type)
         : constantVisitor.value;
@@ -369,549 +632,5 @@ public class ExecutingInvocationUnit extends BasicInvocationUnit {
               false,
               stringConstant.getString(clazz));
     }
-  }
-
-  /**
-   * Returns true if a method call can be called reflectively.
-   *
-   * <p>Currently, supports all methods of String, StringBuilder, StringBuffer.
-   */
-  public boolean isSupportedMethodCall(String internalClassName, String methodName) {
-    return isSupportedClass(internalClassName);
-  }
-
-  /** Returns true if the class is supported by the invocation unit. */
-  public boolean isSupportedClass(String internalClassName) {
-    switch (internalClassName) {
-      case NAME_JAVA_LANG_STRING_BUILDER:
-      case NAME_JAVA_LANG_STRING_BUFFER:
-      case NAME_JAVA_LANG_STRING:
-        return true;
-      default:
-        return false;
-    }
-  }
-
-  /**
-   * Executes a method, by reflectively trying to call the method represented by the given {@link
-   * Call}.
-   *
-   * @param call The method to call.
-   * @param parameters An array containing the parameters values (for a non-static call,
-   *     parameters[0] is the instance.
-   * @return The return value of the method call. Even for a void method, a created value might be
-   *     returned, which might need to be replaced on stack/values (e.g. for Constructors).
-   */
-  public Value executeMethod(ConcreteCall call, Value... parameters) {
-    return executeMethod(
-        call.caller.clazz,
-        (Method) call.caller.member,
-        call.caller.offset,
-        call.getTargetClass(),
-        call.getTargetMethod(),
-        parameters);
-  }
-
-  /**
-   * Executes a method, by reflectively trying to call it with the given parameters.
-   *
-   * @param callingClass The class from where the method is being executed from.
-   * @param callingMethod The method from where the method is being executed from.
-   * @param callingOffset The offset from where the method is being executed from.
-   * @param parameters An array containing the parameters values (for a non-static call,
-   *     parameters[0] is the instance.
-   * @return The return value of the method call. Even for a void method, a created value might be
-   *     returned, which might need to be replaced on stack/values (e.g. for Constructors).
-   */
-  public Value executeMethod(
-      Clazz callingClass,
-      Method callingMethod,
-      int callingOffset,
-      Clazz clazz,
-      Method method,
-      Value... parameters) {
-    if (clazz == null || method == null) {
-      return UNKNOWN_VALUE;
-    }
-
-    boolean isStatic = (method.getAccessFlags() & STATIC) != 0;
-    String baseClassName = clazz.getName();
-    String methodName = method.getName(clazz);
-    String descriptor = method.getDescriptor(clazz);
-    String returnType = ClassUtil.internalMethodReturnType(descriptor);
-    Clazz returnClazz = getReferencedClass(clazz, method, methodName.equals(METHOD_NAME_INIT));
-
-    // On error: return at least a typed reference and potentially a replacement
-    // for the instance, if we know that the method call should return its own instance
-    // according the approximation of `returnsOwnInstance`.
-    String finalReturnType;
-    if (returnClazz != null && methodName.equals(METHOD_NAME_INIT)) {
-      // Make constructors' return types correspond to their referenced class types
-      finalReturnType = ClassUtil.internalTypeFromClassName(returnClazz.getName());
-    } else {
-      finalReturnType = returnType;
-    }
-    BiFunction<ReferenceValue, Object, Value> errorHandler =
-        (instance, objectId) -> {
-          if (objectId != null
-              && returnsOwnInstance(
-                  finalReturnType,
-                  methodName,
-                  descriptor,
-                  isStatic,
-                  instance == null ? null : instance.internalType())) {
-            return valueFactory.createReferenceValueForId(
-                finalReturnType, returnClazz, isNullOrFinal(returnClazz), true, objectId);
-          } else if (isInternalPrimitiveType(finalReturnType)) {
-            return createPrimitiveValue(finalReturnType);
-          } else {
-            return valueFactory.createValue(
-                finalReturnType, returnClazz, isNullOrFinal(returnClazz), true);
-          }
-        };
-
-    ReferenceValue instance =
-        !isStatic && parameters[0] instanceof ReferenceValue
-            ? parameters[0].referenceValue()
-            : null;
-    Object objectId =
-        instance instanceof IdentifiedReferenceValue
-            ? ((IdentifiedReferenceValue) instance).id
-            : null;
-
-    if (!isSupportedMethodCall(baseClassName, methodName)) {
-      return errorHandler.apply(instance, objectId);
-    }
-
-    if (!isStatic) {
-      // instance must be at least specific.
-      if (instance == null || !instance.isSpecific()) {
-        return errorHandler.apply(instance, objectId);
-      }
-    }
-
-    // if this is a non-static call, the first parameter is the instance, so all accesses to the
-    // arrays need to be offset by 1.
-    // if this is a static call, the first parameter is actually the first.
-    int paramOffset = isStatic ? 0 : 1;
-
-    // check if any of the parameters is Unknown. If yes, the result is unknown as well.
-    for (int i = paramOffset; i < parameters.length; i++) {
-      if (!parameters[i].isParticular()) {
-        return errorHandler.apply(instance, objectId);
-      }
-    }
-
-    boolean resultMayBeNull = true;
-    boolean resultMayBeExtension = true;
-    Object callingInstance = null; // null for static
-    Object methodResult;
-
-    try {
-      // collect all class types of the parameters (to search for the correct method reflectively).
-      Class<?>[] parameterClasses = ReflectiveMethodCallUtil.stringtypesToClasses(descriptor);
-
-      // collect all objects of the parameters.
-      Object[] parameterObjects = new Object[parameters.length - paramOffset];
-      for (int i = paramOffset; i < parameters.length; i++) {
-        parameterObjects[i - paramOffset] =
-            ReflectiveMethodCallUtil.getObjectForValue(
-                parameters[i], parameterClasses[i - paramOffset]);
-      }
-
-      if (methodName.equals(METHOD_NAME_INIT)) // CTOR
-      {
-        methodResult =
-            ReflectiveMethodCallUtil.callConstructor(
-                externalClassName(baseClassName), parameterClasses, parameterObjects);
-
-        resultMayBeNull = false; // the return of the ctor will not be null if it does not throw.
-        resultMayBeExtension = false; // the return of the ctor will always be this specific type.
-      } else // non-constructor method call.
-      {
-        if (instance != null && instance.isParticular()) {
-          switch (baseClassName) {
-              // create a copy of the object stored in the ParticularReferenceValue.
-            case NAME_JAVA_LANG_STRING_BUILDER:
-              callingInstance = new StringBuilder((StringBuilder) instance.value());
-              break;
-            case NAME_JAVA_LANG_STRING_BUFFER:
-              callingInstance = new StringBuffer((StringBuffer) instance.value());
-              break;
-            case NAME_JAVA_LANG_STRING:
-              callingInstance = (String) instance.value();
-              break;
-          }
-        }
-
-        if (isStatic || callingInstance != null) {
-          methodResult =
-              callMethod(
-                  ClassUtil.externalClassName(baseClassName),
-                  methodName,
-                  callingInstance,
-                  parameterClasses,
-                  parameterObjects);
-        } else {
-          return errorHandler.apply(instance, objectId);
-        }
-      }
-    } catch (NullPointerException | InvocationTargetException e) {
-      // a parameter might be null, and the method might not be able to handle it ->
-      // NullPointerException, or
-      // an index might be wrongly / not initialized -> StringIndexOutOfBoundsException.
-      if (DEBUG) {
-        System.err.println(
-            "Invocation exception during method execution: "
-                + e.getClass().getSimpleName()
-                + ": - "
-                + e.getMessage());
-      }
-      return errorHandler.apply(instance, objectId);
-    } catch (RuntimeException
-        | ClassNotFoundException
-        | NoSuchMethodException
-        | IllegalAccessException
-        | InstantiationException e) {
-      if (DEBUG) {
-        System.err.println(
-            "Error reflectively calling "
-                + baseClassName
-                + "."
-                + methodName
-                + descriptor
-                + ": "
-                + e.getClass().getSimpleName()
-                + " - "
-                + e.getMessage());
-      }
-      return errorHandler.apply(instance, objectId);
-    }
-
-    // If the return value is a primitive, store this inside its corresponding ParticularValue, e.g.
-    // int -> ParticularIntegerValue.
-    if (returnType.length() == 1 && isInternalPrimitiveType(returnType)) {
-      return createPrimitiveValue(methodResult, returnType);
-    }
-
-    // If the return value is a primitive array, store this in a (Detailed)ArrayReferenceValue
-    if (ClassUtil.internalArrayTypeDimensionCount(returnType) == 1
-        && isInternalPrimitiveType(ClassUtil.internalTypeFromArrayType(returnType))) {
-      return valueFactory.createArrayReferenceValue(
-          returnType,
-          null,
-          valueFactory.createIntegerValue(Array.getLength(methodResult)),
-          methodResult);
-    }
-
-    // If it is not a primitiveValue, it will be stored in a ParticularReferenceValue.
-    // If the return type is void, we still return an object, since this might need to be replaced
-    // on stack/variables.
-    // To create a referenceValue with a correct type (i.e. not void), we update the type from the
-    // instance we called upon.
-    if (!isStatic && returnType.equals("V")) {
-      returnType = instance.referenceValue().getType();
-    }
-
-    // If there ID is already know, use the same ID;
-    // unless the instance modifies itself or is different.
-    if (objectId != null
-        && (alwaysModifiesInstance(baseClassName, methodName) || callingInstance == methodResult)) {
-      return valueFactory.createReferenceValueForId(
-          returnType,
-          // check necessary for primitive arrays, in case the method returns a primitive array its
-          // last referenced class will be
-          // its last parameter (null correctly just if it has no reference class parameters), since
-          // primitive types are not a referenced class
-          ClassUtil.isInternalPrimitiveType(ClassUtil.internalTypeFromArrayType(returnType))
-              ? null
-              : returnClazz,
-          resultMayBeExtension,
-          resultMayBeNull,
-          objectId,
-          methodResult);
-    } else {
-      return valueFactory.createReferenceValue(
-          returnType,
-          // check necessary for primitive arrays, in case the method returns a primitive array its
-          // last referenced class will be
-          // its last parameter (null correctly just if it has no reference class parameters), since
-          // primitive types are not a referenced class
-          ClassUtil.isInternalPrimitiveType(ClassUtil.internalTypeFromArrayType(returnType))
-              ? null
-              : returnClazz,
-          resultMayBeExtension,
-          resultMayBeNull,
-          callingClass,
-          callingMethod,
-          callingOffset,
-          methodResult);
-    }
-  }
-
-  // private methods
-
-  /**
-   * Create a ParticularValue containing the object, using the factory of this instance
-   *
-   * @param type the type the resulting Value should have.
-   * @return the new ParticularValue, or null if the type cannot be converted to a ParticularValue.
-   */
-  private Value createPrimitiveValue(String type) {
-    switch (type.charAt(0)) {
-      case BOOLEAN:
-      case INT:
-      case SHORT:
-      case BYTE:
-      case CHAR:
-        return valueFactory.createIntegerValue();
-      case FLOAT:
-        return valueFactory.createFloatValue();
-      case DOUBLE:
-        return valueFactory.createDoubleValue();
-      case LONG:
-        return valueFactory.createLongValue();
-    }
-    // unknown type
-    return null;
-  }
-
-  /**
-   * Create a ParticularValue containing the object, using the factory of this instance
-   *
-   * @param obj the object to wrap.
-   * @param type the type the resulting Value should have.
-   * @return the new ParticularValue, or null if the type cannot be converted to a ParticularValue.
-   */
-  private Value createPrimitiveValue(Object obj, String type) {
-    switch (type.charAt(0)) {
-      case BOOLEAN:
-        return valueFactory.createIntegerValue(((Boolean) obj) ? 1 : 0);
-      case CHAR:
-        return valueFactory.createIntegerValue((Character) obj);
-      case BYTE:
-        return valueFactory.createIntegerValue((Byte) obj);
-      case SHORT:
-        return valueFactory.createIntegerValue((Short) obj);
-      case INT:
-        return valueFactory.createIntegerValue((Integer) obj);
-      case FLOAT:
-        return valueFactory.createFloatValue((Float) obj);
-      case DOUBLE:
-        return valueFactory.createDoubleValue((Double) obj);
-      case LONG:
-        return valueFactory.createLongValue((Long) obj);
-    }
-    // unknown type
-    return null;
-  }
-
-  /**
-   * Iterate the variables and replace all occurrences of oldValue with newValue.
-   *
-   * @param newValue the value which should be put in.
-   * @param oldValue the value to replace.
-   * @param variables the variables to look through.
-   */
-  private void replaceReferenceInVariables(Value newValue, Value oldValue, Variables variables) {
-    if (oldValue.isSpecific()) {
-      // we need to replace all instances on the stack and in the vars with new instances now.
-      if (variables != null) {
-        for (int i = 0; i < variables.size(); i++) {
-          Value value = variables.getValue(i);
-          if (Objects.equals(value, oldValue)) {
-            variables.store(i, newValue);
-          }
-          if (value != null && value.isCategory2()) {
-            i++;
-          }
-        }
-      }
-    }
-  }
-
-  /**
-   * Iterate the stack and replace all occurrences of oldValue with newValue.
-   *
-   * @param newValue the value which should be put in.
-   * @param oldValue the value to replace.
-   * @param stack the stack to look through.
-   */
-  private void replaceReferenceOnStack(Value newValue, Value oldValue, Stack stack) {
-    if (oldValue.isSpecific()) {
-      for (int i = 0; i < stack.size(); i++) {
-        Value top = stack.getTop(i);
-        if (Objects.equals(top, oldValue)) {
-          stack.setTop(i, newValue);
-        }
-      }
-    }
-  }
-
-  /**
-   * Returns true, if a call to internalClassName.methodName should return a new (i.e. not-linked)
-   * instance.
-   *
-   * @param internalClassName full class name of the base class of the method (e.g.
-   *     java/lang/StringBuilder).
-   * @param methodName method name.
-   * @return if it should create a new instance.
-   */
-  public boolean alwaysReturnsNewInstance(String internalClassName, String methodName) {
-    return alwaysReturnsNewInstance
-        .getOrDefault(internalClassName, new HashSet<>())
-        .contains(methodName);
-  }
-
-  /**
-   * Returns true, if a call to internalClassName.methodName always modified the called upon
-   * instance. The modified value will be returned by the reflective method call
-   *
-   * @param internalClassName full class name of the base class of the method (e.g.
-   *     java/lang/StringBuilder).
-   * @param methodName method name.
-   * @return if the instance is always modified.
-   */
-  private boolean alwaysModifiesInstance(String internalClassName, String methodName) {
-    // The constructor always modifies the instance.
-    return methodName.equals(METHOD_NAME_INIT)
-        || alwaysModifiesInstance
-            .getOrDefault(internalClassName, new HashSet<>())
-            .contains(methodName);
-  }
-
-  /**
-   * Determines if the stack/variables need to be updated.
-   *
-   * <p>Limitations: We are only checking if the instance of the call was modified, i.e. - for
-   * static calls, no value should be replaced on stack/variables (since no instance exists), and -
-   * the method call assumes that the parameters are not changed.
-   *
-   * <p>This is an approximation which works well for StringBuilder/StringBuffer and Strings.
-   */
-  public boolean returnsOwnInstance(Clazz clazz, Method method, Value instance) {
-    if (!(instance instanceof ReferenceValue)) {
-      return false;
-    }
-
-    String instanceType = instance.internalType();
-    String internalClassName = clazz.getName();
-    String methodName = method.getName(clazz);
-    boolean isStatic = (method.getAccessFlags() & STATIC) != 0;
-
-    return returnsOwnInstance(
-        internalClassName, methodName, method.getDescriptor(clazz), isStatic, instanceType);
-  }
-
-  /**
-   * Determines if the stack/variables need to be updated.
-   *
-   * <p>Limitations: We are only checking if the instance of the call was modified, i.e. - for
-   * static calls, no value should be replaced on stack/variables (since no instance exists), and -
-   * the method call assumes that the parameters are not changed.
-   *
-   * <p>This is an approximation which works well for StringBuilder/StringBuffer and Strings.
-   */
-  private boolean returnsOwnInstance(
-      String internalClassName,
-      String methodName,
-      String methodDescriptor,
-      boolean isStatic,
-      String instanceType) {
-    String returnType = ClassUtil.internalMethodReturnType(methodDescriptor);
-
-    if (isInternalPrimitiveType(returnType)) {
-      return false;
-    }
-
-    if (isStatic) {
-      // For a static method, there is never an instance to update,
-      // we do not track internal state, so no static internals of the class are stored.
-      return false;
-    }
-
-    if (alwaysReturnsNewInstance(internalClassName, methodName)) {
-      // Denylist (Case 1).
-      // The value returned by the PartialEvaluator never needs to be replaced.
-      return false;
-    }
-
-    if (alwaysModifiesInstance(internalClassName, methodName)
-        || // Allowlist (Case 2). The instance always needs to be replaced.
-        Objects.equals(returnType, instanceType)) // Approximation (Case 3)
-    // For now, we assume that the instance is changed, if the method is not in the Denylist, and
-    // the returnType equals
-    // the type of the called upon instance. E.g., if StringBuilder.append() returns a
-    // StringBuilder, we assume that this
-    // is the instance which needs to be replaced.
-    {
-      return true;
-    }
-
-    return false;
-  }
-
-  private void updateStackAndVariables(
-      Clazz clazz,
-      AnyMethodrefConstant anyMethodrefConstant,
-      String returnType,
-      Value reflectedReturnValue) {
-    String baseClassName = anyMethodrefConstant.getClassName(clazz);
-    String methodName = anyMethodrefConstant.getName(clazz);
-
-    if (returnsOwnInstance(
-        clazz,
-        anyMethodrefConstant.referencedMethod,
-        parameters.length > 0 ? parameters[0] : null)) {
-      Value updateValue = reflectedReturnValue;
-
-      // If the reflective method call fails, it returned null. We create an unknown value to use as
-      // replacement on stack/variables.
-      // this can happen e.g. if we have a substring with incorrect lengths, or unknown values in
-      // the parameters, etc.
-      if (updateValue == null) {
-        // To create a correct (failed) object, we need to know the type. For void methods, we use
-        // the type of the instance
-        updateValue =
-            valueFactory.createValue(
-                (returnType.charAt(0) == VOID)
-                    ? ClassUtil.internalTypeFromClassName(baseClassName)
-                    : returnType,
-                getReferencedClass(anyMethodrefConstant, methodName.equals(METHOD_NAME_INIT)),
-                true,
-                true);
-      }
-
-      replaceReferenceInVariables(updateValue, parameters[0], variables);
-      replaceReferenceOnStack(updateValue, parameters[0], stack);
-    }
-  }
-
-  private Clazz getReferencedClass(Clazz clazz, Method method, boolean isCtor) {
-    if (isCtor) {
-      return clazz; // this is the class of "this", i.e., the type of this constructor.
-    }
-
-    // extract the class from the referenced classes
-    ReturnClassExtractor returnClassExtractor = new ReturnClassExtractor();
-    method.accept(clazz, returnClassExtractor);
-    return returnClassExtractor.returnClass; // can be null
-  }
-
-  /**
-   * Returns the class of the returnClassPool type, if available, null otherwise. For a Constructor,
-   * we always return a type, even if the return type of the method would be void. This is required,
-   * since we need to handle constructors differently in general (see Javadoc).
-   */
-  private Clazz getReferencedClass(AnyMethodrefConstant anyMethodrefConstant, boolean isCtor) {
-    if (isCtor) {
-      return anyMethodrefConstant
-          .referencedClass; // this is the class of "this", i.e., the type of this constructor.
-    }
-
-    // extract the class from the referenced classes
-    ReturnClassExtractor returnClassExtractor = new ReturnClassExtractor();
-    anyMethodrefConstant.referencedMethodAccept(returnClassExtractor);
-    return returnClassExtractor.returnClass; // can be null
   }
 }

--- a/base/src/main/java/proguard/evaluation/executor/Executor.java
+++ b/base/src/main/java/proguard/evaluation/executor/Executor.java
@@ -1,0 +1,89 @@
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2023 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proguard.evaluation.executor;
+
+import java.util.Optional;
+import proguard.classfile.MethodSignature;
+import proguard.evaluation.ExecutingInvocationUnit;
+import proguard.evaluation.executor.instancehandler.ExecutorInstanceHandler;
+import proguard.evaluation.executor.matcher.ExecutorMatcher;
+import proguard.evaluation.value.ReferenceValue;
+import proguard.evaluation.value.Value;
+
+/**
+ * This abstract class specifies a modular component which can be added to a {@link
+ * ExecutingInvocationUnit} in order to extend its capabilities. An {@link Executor} specifies which
+ * method calls it supports, what methods return their own instance and how a method result is
+ * calculated.
+ */
+public abstract class Executor {
+  protected ExecutorMatcher executorMatcher;
+  protected ExecutorInstanceHandler instanceHandler;
+
+  /**
+   * Calculate the result of a given method. This is the return value for a non-constructor method
+   * (<c>null</c> if it returns <c>void</c>) and the instantiated object for a constructor.
+   *
+   * @param methodData Information about the called method.
+   * @param instance The {@link ReferenceValue} of the instance, <c>null</c> for static methods.
+   * @param callingInstance The instance object, <c>null</c> for static methods.
+   * @param parameters An array of the parameter values of the method call.
+   * @return The result of the method call wrapped in an optional. <code>Optional.empty()</code> if
+   *     a result could not be calculated.
+   */
+  public abstract Optional<Object> getMethodResult(
+      MethodExecutionInfo methodData,
+      ReferenceValue instance,
+      Object callingInstance,
+      Value[] parameters);
+
+  /**
+   * Returns whether a certain method invocation is supported.
+   *
+   * @param signature The method signature.
+   * @return whether the method invocation is supported.
+   */
+  public boolean isSupportedMethodCall(MethodSignature signature) {
+    return executorMatcher.matches(signature);
+  }
+
+  /**
+   * Returns whether a certain method invocation is assumed to return its own instance. This
+   * indicates whether replacing the instance reference in the stack and variables is necessary.
+   *
+   * @param signature The method signature.
+   * @param returnsSameTypeAsInstance whether the method has matching return and instance types
+   * @return whether the method returns its own instance.
+   */
+  public boolean returnsOwnInstance(MethodSignature signature, boolean returnsSameTypeAsInstance) {
+    return returnsSameTypeAsInstance
+        && instanceHandler.returnsOwnInstance(signature.getClassName(), signature.method);
+  }
+
+  /**
+   * Get an object which will act as the calling instance. If we know that executing the method does
+   * not modify the instance this can just be the same value. Otherwise, a copy should be returned
+   * in order to not change the reference whose state may be of interest at the end of an analysis.
+   *
+   * @param instanceValue The {@link ReferenceValue} of the instance.
+   * @param className The name of the class of the instance.
+   * @return The new calling instance.
+   */
+  public abstract Object getInstanceCopyIfMutable(ReferenceValue instanceValue, String className);
+}

--- a/base/src/main/java/proguard/evaluation/executor/Executor.java
+++ b/base/src/main/java/proguard/evaluation/executor/Executor.java
@@ -47,7 +47,7 @@ public abstract class Executor {
    * @return The result of the method call wrapped in an optional. <code>Optional.empty()</code> if
    *     a result could not be calculated.
    */
-  public abstract Optional<Object> getMethodResult(
+  public abstract MethodResult<Object> getMethodResult(
       MethodExecutionInfo methodData,
       ReferenceValue instance,
       Object callingInstance,

--- a/base/src/main/java/proguard/evaluation/executor/Executor.java
+++ b/base/src/main/java/proguard/evaluation/executor/Executor.java
@@ -85,5 +85,6 @@ public abstract class Executor {
    * @param className The name of the class of the instance.
    * @return The new calling instance.
    */
-  public abstract Object getInstanceCopyIfMutable(ReferenceValue instanceValue, String className);
+  public abstract Optional<Object> getInstanceCopyIfMutable(
+      ReferenceValue instanceValue, String className);
 }

--- a/base/src/main/java/proguard/evaluation/executor/MethodExecutionInfo.java
+++ b/base/src/main/java/proguard/evaluation/executor/MethodExecutionInfo.java
@@ -1,0 +1,199 @@
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2023 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proguard.evaluation.executor;
+
+import static proguard.classfile.AccessConstants.STATIC;
+import static proguard.classfile.ClassConstants.METHOD_NAME_INIT;
+
+import java.util.Optional;
+import proguard.analysis.datastructure.CodeLocation;
+import proguard.analysis.datastructure.callgraph.ConcreteCall;
+import proguard.classfile.Clazz;
+import proguard.classfile.Method;
+import proguard.classfile.MethodSignature;
+import proguard.classfile.constant.AnyMethodrefConstant;
+import proguard.classfile.util.ClassUtil;
+import proguard.classfile.visitor.ReturnClassExtractor;
+import proguard.evaluation.value.IdentifiedReferenceValue;
+import proguard.evaluation.value.ReferenceValue;
+import proguard.evaluation.value.Value;
+
+/**
+ * This class stores data relevant to modeling the execution of a method and offers methods to
+ * extract additional information.
+ */
+public class MethodExecutionInfo {
+  private final MethodSignature signature;
+  private final CodeLocation caller;
+  private final boolean isConstructor;
+  private final boolean isStatic;
+  private final String returnType;
+  private final Clazz resultClass;
+  private final String resultType;
+
+  /**
+   * Constructs a MethodExecutionInfo.
+   *
+   * @param clazz The referenced class.
+   * @param method The referenced method.
+   * @param caller The code location of the call site. May be null.
+   */
+  public MethodExecutionInfo(Clazz clazz, Method method, CodeLocation caller) {
+    signature = new MethodSignature(clazz, method);
+    this.caller = caller;
+
+    returnType = ClassUtil.internalMethodReturnType(signature.descriptor.toString());
+    isConstructor = signature.method.equals(METHOD_NAME_INIT);
+    isStatic = (method.getAccessFlags() & STATIC) != 0;
+
+    if (isConstructor) {
+      // For a Constructor, we always return a type, even if the return type of the method would be
+      // void.
+      resultClass = clazz;
+    } else {
+      // Get the class of the return type, if available, null otherwise.
+      ReturnClassExtractor returnClassExtractor = new ReturnClassExtractor();
+      method.accept(clazz, returnClassExtractor);
+      resultClass = returnClassExtractor.returnClass;
+    }
+    resultType =
+        resultClass != null && isConstructor
+            ? ClassUtil.internalTypeFromClassName(resultClass.getName())
+            : returnType;
+  }
+
+  /**
+   * Constructs a MethodExecutionInfo.
+   *
+   * @param anyMethodrefConstant A method reference constant. Requires referenced class to be
+   *     initialized (using {@link proguard.classfile.util.ClassReferenceInitializer}.
+   * @param caller The code location of the call site. May be null.
+   */
+  public MethodExecutionInfo(AnyMethodrefConstant anyMethodrefConstant, CodeLocation caller) {
+    this(anyMethodrefConstant.referencedClass, anyMethodrefConstant.referencedMethod, caller);
+  }
+
+  /**
+   * Constructs a MethodExecutionInfo.
+   *
+   * @param call the concrete call.
+   */
+  public MethodExecutionInfo(ConcreteCall call) {
+    this(call.getTargetClass(), call.getTargetMethod(), call.caller);
+  }
+
+  /** Get the method signature of the method */
+  public MethodSignature getSignature() {
+    return signature;
+  }
+
+  /** Get the code location of the call site */
+  public Optional<CodeLocation> getCaller() {
+    return Optional.ofNullable(caller);
+  }
+
+  /** Return whether the method is a constructor. */
+  public boolean isConstructor() {
+    return isConstructor;
+  }
+
+  /** Return whether the method is static. */
+  public boolean isStatic() {
+    return isStatic;
+  }
+
+  /** Get the return type of the method. */
+  public String getReturnType() {
+    return returnType;
+  }
+
+  /**
+   * Get the result class of the method. If the method is a constructor, this will be the class of
+   * the instance.
+   */
+  public Clazz getResultClass() {
+    return resultClass;
+  }
+
+  /**
+   * Get the result type of the method. If the method is a constructor, this will be the type of the
+   * instance.
+   */
+  public String getResultType() {
+    return resultType;
+  }
+
+  /** Get the {@link ReferenceValue} of the instance. */
+  public Optional<ReferenceValue> getInstanceValue(Value instance) {
+    return instance instanceof ReferenceValue
+        ? Optional.of(instance.referenceValue())
+        : Optional.empty();
+  }
+
+  /** Get the reference value of the instance. */
+  public Optional<ReferenceValue> getInstanceValue(Value[] parameters) {
+    return parameters != null && !isStatic ? getInstanceValue(parameters[0]) : Optional.empty();
+  }
+
+  /** Get the object ID for the instance value. */
+  public Optional<Object> getObjectId(ReferenceValue instanceValue) {
+    return instanceValue instanceof IdentifiedReferenceValue
+        ? Optional.of(((IdentifiedReferenceValue) instanceValue).id)
+        : Optional.empty();
+  }
+
+  /** Get the calling instance using the copy behavior defined by the executor. */
+  public Optional<Object> getCallingInstance(Executor executor, Value[] parameters) {
+    return getInstanceValue(parameters)
+        .flatMap(instanceValue -> getCallingInstance(executor, instanceValue));
+  }
+
+  /** Get the calling instance using the copy behavior defined by the executor. */
+  public Optional<Object> getCallingInstance(Executor executor, ReferenceValue instanceValue) {
+    return (instanceValue != null && instanceValue.isParticular() && !isConstructor)
+        ? Optional.of(executor.getInstanceCopyIfMutable(instanceValue, signature.getClassName()))
+        : Optional.empty();
+  }
+
+  /** Get the type of the instance. */
+  public Optional<String> getInstanceType(ReferenceValue instanceValue) {
+    return instanceValue != null ? Optional.of(instanceValue.internalType()) : Optional.empty();
+  }
+
+  /** Return whether the return and instance types of the method match. */
+  public boolean returnsSameTypeAsInstance(Value[] parameters) {
+    return getInstanceValue(parameters).map(this::returnsSameTypeAsInstance).orElse(false);
+  }
+
+  /** Return whether the return and instance types of the method match. */
+  public boolean returnsSameTypeAsInstance(Value instance) {
+    return getInstanceValue(instance).map(this::returnsSameTypeAsInstance).orElse(false);
+  }
+
+  /** Return whether the return and instance types of the method match. */
+  public boolean returnsSameTypeAsInstance(ReferenceValue instance) {
+    return getInstanceValue(instance)
+        .map(
+            instanceValue ->
+                getInstanceType(instanceValue)
+                    .map(instanceType -> instanceType.equals(returnType))
+                    .orElse(false))
+        .orElse(false);
+  }
+}

--- a/base/src/main/java/proguard/evaluation/executor/MethodExecutionInfo.java
+++ b/base/src/main/java/proguard/evaluation/executor/MethodExecutionInfo.java
@@ -27,6 +27,7 @@ import proguard.analysis.datastructure.callgraph.ConcreteCall;
 import proguard.classfile.Clazz;
 import proguard.classfile.Method;
 import proguard.classfile.MethodSignature;
+import proguard.classfile.Signature;
 import proguard.classfile.constant.AnyMethodrefConstant;
 import proguard.classfile.util.ClassUtil;
 import proguard.classfile.visitor.ReturnClassExtractor;
@@ -55,7 +56,7 @@ public class MethodExecutionInfo {
    * @param caller The code location of the call site. May be null.
    */
   public MethodExecutionInfo(Clazz clazz, Method method, CodeLocation caller) {
-    signature = new MethodSignature(clazz, method);
+    signature = (MethodSignature) Signature.of(clazz, method);
     this.caller = caller;
 
     returnType = ClassUtil.internalMethodReturnType(signature.descriptor.toString());

--- a/base/src/main/java/proguard/evaluation/executor/MethodExecutionInfo.java
+++ b/base/src/main/java/proguard/evaluation/executor/MethodExecutionInfo.java
@@ -168,7 +168,7 @@ public class MethodExecutionInfo {
   /** Get the calling instance using the copy behavior defined by the executor. */
   public Optional<Object> getCallingInstance(Executor executor, ReferenceValue instanceValue) {
     return (instanceValue != null && instanceValue.isParticular() && !isConstructor)
-        ? Optional.of(executor.getInstanceCopyIfMutable(instanceValue, signature.getClassName()))
+        ? executor.getInstanceCopyIfMutable(instanceValue, signature.getClassName())
         : Optional.empty();
   }
 

--- a/base/src/main/java/proguard/evaluation/executor/MethodResult.java
+++ b/base/src/main/java/proguard/evaluation/executor/MethodResult.java
@@ -1,0 +1,109 @@
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2023 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proguard.evaluation.executor;
+
+import java.util.Objects;
+import java.util.function.Function;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * This class is a generic wrapper for a result. It is similar to {@link java.util.Optional} with a
+ * key difference: An instance of this class is allowed to have a value of null and be non-empty.
+ * This type can also convey the notion of failure with null still being a valid value.
+ *
+ * @param <T> The type of the result that is wrapped.
+ */
+public class MethodResult<T> {
+  private static final MethodResult<?> EMPTY = new MethodResult<>();
+
+  @Nullable private final T value;
+  boolean isPresent;
+
+  private MethodResult() {
+    value = null;
+    this.isPresent = false;
+  }
+
+  private MethodResult(@Nullable T value) {
+    this.value = value;
+    isPresent = true;
+  }
+
+  /** Returns an empty {@link MethodResult} meaning there is no value present. */
+  public static <T> MethodResult<T> empty() {
+    @SuppressWarnings("unchecked")
+    MethodResult<T> t = (MethodResult<T>) EMPTY;
+    return t;
+  }
+
+  /**
+   * Returns a {@link MethodResult} that wraps the given value. This method will never return empty.
+   */
+  public static <T> MethodResult<T> of(@Nullable T value) {
+    return new MethodResult<>(value);
+  }
+
+  /** Returns if a value is present */
+  public boolean isPresent() {
+    return isPresent;
+  }
+
+  /** Returns if no value is present */
+  public boolean isEmpty() {
+    return !isPresent;
+  }
+
+  /** Applies the mapper function to the value if it is present. */
+  public <U> MethodResult<U> map(Function<? super T, ? extends U> mapper) {
+    Objects.requireNonNull(mapper);
+    if (!isPresent) {
+      return empty();
+    } else {
+      return MethodResult.of(mapper.apply(value));
+    }
+  }
+
+  /** If a value is present return it, else <code>other</code> is returned. */
+  public T orElse(T other) {
+    return isPresent ? value : other;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof MethodResult<?>)) {
+      return false;
+    }
+
+    return Objects.equals(value, ((MethodResult<?>) obj).value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(value);
+  }
+
+  @Override
+  public String toString() {
+    return value != null ? ("MethodResult[" + value + "]") : "MethodResult.empty";
+  }
+}

--- a/base/src/main/java/proguard/evaluation/executor/ReflectionExecutor.java
+++ b/base/src/main/java/proguard/evaluation/executor/ReflectionExecutor.java
@@ -1,0 +1,319 @@
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2023 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proguard.evaluation.executor;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Optional;
+import proguard.classfile.JavaConstants;
+import proguard.classfile.JavaTypeConstants;
+import proguard.classfile.MethodDescriptor;
+import proguard.classfile.TypeConstants;
+import proguard.classfile.util.ClassUtil;
+import proguard.evaluation.value.ReferenceValue;
+import proguard.evaluation.value.Value;
+
+/**
+ * This {@link Executor} provides an implementation for {@link Executor#getMethodResult} which tries
+ * to resolve the method at runtime and execute it using Java's reflection API {@link
+ * java.lang.reflect}.
+ */
+public abstract class ReflectionExecutor extends Executor {
+  @Override
+  public Optional<Object> getMethodResult(
+      MethodExecutionInfo methodInfo,
+      ReferenceValue instance,
+      Object callingInstance,
+      Value[] parameters) {
+    if (!methodInfo.isStatic() && (instance == null || !instance.isSpecific())) {
+      // Instance must at least be specific.
+      return Optional.empty();
+    }
+
+    int paramOffset = methodInfo.isStatic() ? 0 : 1;
+    if (!Arrays.stream(parameters).skip(paramOffset).allMatch(Value::isParticular)) {
+      // All parameters must be particular.
+      return Optional.empty();
+    }
+
+    ReflectionParameters reflectionParameters =
+        new ReflectionParameters(methodInfo.getSignature().descriptor, parameters, paramOffset);
+
+    if (methodInfo.isConstructor()) {
+      try {
+        Class<?> baseClass =
+            Class.forName(ClassUtil.externalClassName(methodInfo.getSignature().getClassName()));
+
+        // Try to resolve the constructor reflectively and create a new instance.
+        return Optional.of(
+            baseClass
+                .getConstructor(reflectionParameters.classes)
+                .newInstance(reflectionParameters.objects));
+      } catch (ClassNotFoundException
+          | NoSuchMethodException
+          | SecurityException
+          | InstantiationException
+          | IllegalAccessException
+          | IllegalArgumentException
+          | InvocationTargetException e) {
+        return Optional.empty();
+      }
+    } else {
+      try {
+        Class<?> baseClass =
+            Class.forName(ClassUtil.externalClassName(methodInfo.getSignature().getClassName()));
+        if (callingInstance == null && !methodInfo.isStatic()) throw new IllegalArgumentException();
+
+        // Try to resolve the method via reflection and invoke the method.
+        return Optional.of(
+            baseClass
+                .getMethod(methodInfo.getSignature().method, reflectionParameters.classes)
+                .invoke(callingInstance, reflectionParameters.objects));
+      } catch (ClassNotFoundException
+          | NoSuchMethodException
+          | SecurityException
+          | IllegalAccessException
+          | IllegalArgumentException
+          | InvocationTargetException e) {
+        return Optional.empty();
+      }
+    }
+  }
+
+  /**
+   * This class represents the parameters needed for invoking a method using Java's reflection API.
+   * It is capable of parsing these parameters from a
+   */
+  private static class ReflectionParameters {
+    private final Object[] objects;
+    private final Class<?>[] classes;
+
+    /**
+     * Parse information on a method call into the parameters needed for calling the method via
+     * reflection.
+     *
+     * @param descriptor The descriptor of the method.
+     * @param parameters An array of the parameters of the method.
+     * @param paramOffset 0 if the method is static, otherwise 1.
+     */
+    public ReflectionParameters(MethodDescriptor descriptor, Value[] parameters, int paramOffset)
+        throws IllegalArgumentException {
+      int len = parameters.length - paramOffset;
+      if (descriptor.getArgumentTypes().size() != len) {
+        throw new IllegalArgumentException("Parameter count does not match the method descriptor.");
+      }
+
+      objects = new Object[len];
+      classes = new Class<?>[len];
+      for (int index = 0; index < len; index++) {
+        String internalType = descriptor.getArgumentTypes().get(index);
+        Value parameter = parameters[index + paramOffset];
+
+        if (!ClassUtil.isInternalArrayType(internalType)) {
+          Class<?> cls;
+          try {
+            cls = getSingleClass(internalType);
+          } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException("Descriptor type refers to an unknown class.");
+          }
+
+          classes[index] = cls;
+          objects[index] = getSingleObject(cls, parameter);
+        } else {
+          String innerType = ClassUtil.internalTypeFromArrayType(internalType);
+          if (ClassUtil.isInternalArrayType(innerType)) {
+            // unreachable because of DetailedArrayValues not supporting >1D, therefore not being
+            // particular
+            throw new IllegalArgumentException("Only 1D arrays are supported.");
+          }
+
+          Value[] valuesArray = (Value[]) parameter.referenceValue().value();
+          Class<?> innerClass;
+          try {
+            innerClass = getSingleClass(innerType);
+          } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException("Descriptor type refers to an unknown class.");
+          }
+
+          Object arrayObject = getArrayObject(innerClass, valuesArray);
+          classes[index] = arrayObject != null ? arrayObject.getClass() : null;
+          objects[index] = arrayObject;
+        }
+      }
+    }
+
+    private static Class<?> getSingleClass(String type) throws ClassNotFoundException {
+      switch (type.charAt(0)) {
+        case TypeConstants.VOID:
+          return void.class;
+        case TypeConstants.BOOLEAN:
+          return boolean.class;
+        case TypeConstants.BYTE:
+          return byte.class;
+        case TypeConstants.CHAR:
+          return char.class;
+        case TypeConstants.SHORT:
+          return short.class;
+        case TypeConstants.INT:
+          return int.class;
+        case TypeConstants.LONG:
+          return long.class;
+        case TypeConstants.FLOAT:
+          return float.class;
+        case TypeConstants.DOUBLE:
+          return double.class;
+        case TypeConstants.CLASS_START:
+          String internalClass = ClassUtil.internalClassNameFromClassType(type);
+          return Class.forName(ClassUtil.externalClassName(internalClass));
+        default:
+          throw new ClassNotFoundException();
+      }
+    }
+
+    private static int getIntValue(Value value) {
+      return value.integerValue().value();
+    }
+
+    private static char getCharValue(Value value) {
+      return (char) value.integerValue().value();
+    }
+
+    private static boolean getBooleanValue(Value value) {
+      return value.integerValue().value() != 0;
+    }
+
+    private static byte getByteValue(Value value) {
+      return (byte) value.integerValue().value();
+    }
+
+    private static short getShortValue(Value value) {
+      return (short) value.integerValue().value();
+    }
+
+    /**
+     * Extract an object for the particular value of a {@link Value}.
+     *
+     * @param cls The class of the value determined using the descriptor.
+     * @param value The {@link Value} the object is extracted from.
+     * @return The extracted value cast to an {@link Object}.
+     */
+    private static Object getSingleObject(Class<?> cls, Value value) {
+      switch (value.computationalType()) {
+        case Value.TYPE_INTEGER:
+          return (cls == char.class || cls == Character.class)
+              ? getCharValue(value)
+              : (cls == byte.class || cls == Byte.class)
+                  ? getByteValue(value)
+                  : (cls == short.class || cls == Short.class)
+                      ? getShortValue(value)
+                      : (cls == boolean.class || cls == Boolean.class)
+                          ? getBooleanValue(value)
+                          : getIntValue(value);
+        case Value.TYPE_LONG:
+          return value.longValue().value();
+        case Value.TYPE_FLOAT:
+          return value.floatValue().value();
+        case Value.TYPE_DOUBLE:
+          return value.doubleValue().value();
+        case Value.TYPE_REFERENCE:
+          return value.referenceValue().value();
+        default:
+          return null;
+      }
+    }
+
+    /**
+     * Extract an object for the particular values of an array of {@link Value}s.
+     *
+     * @param cls The class for the inner type of the array.
+     * @param values An array of values.
+     * @return The extracted array cast to an {@link Object}.
+     */
+    private static Object getArrayObject(Class<?> cls, Value[] values) {
+      int length = values.length;
+      switch (cls.getName()) {
+          // handle arrays of primitive types separately
+        case JavaTypeConstants.INT:
+        case JavaConstants.TYPE_JAVA_LANG_INTEGER:
+          int[] arrayOfIntegers = new int[length];
+          for (int index = 0; index < length; index++) {
+            arrayOfIntegers[index] = getIntValue(values[index]);
+          }
+          return arrayOfIntegers;
+        case JavaTypeConstants.LONG:
+        case JavaConstants.TYPE_JAVA_LANG_LONG:
+          long[] arrayOfLongs = new long[length];
+          for (int index = 0; index < length; index++) {
+            arrayOfLongs[index] = values[index].longValue().value();
+          }
+          return arrayOfLongs;
+        case JavaTypeConstants.CHAR:
+        case JavaConstants.TYPE_JAVA_LANG_CHARACTER:
+          char[] arrayOfChars = new char[length];
+          for (int index = 0; index < length; index++) {
+            arrayOfChars[index] = getCharValue(values[index]);
+          }
+          return arrayOfChars;
+        case JavaTypeConstants.BYTE:
+        case JavaConstants.TYPE_JAVA_LANG_BYTE:
+          byte[] arrayOfBytes = new byte[length];
+          for (int index = 0; index < length; index++) {
+            arrayOfBytes[index] = getByteValue(values[index]);
+          }
+          return arrayOfBytes;
+        case JavaTypeConstants.SHORT:
+        case JavaConstants.TYPE_JAVA_LANG_SHORT:
+          short[] arrayOfShorts = new short[length];
+          for (int index = 0; index < length; index++) {
+            arrayOfShorts[index] = getShortValue(values[index]);
+          }
+          return arrayOfShorts;
+        case JavaTypeConstants.BOOLEAN:
+        case JavaConstants.TYPE_JAVA_LANG_BOOLEAN:
+          boolean[] arrayOfBooleans = new boolean[length];
+          for (int index = 0; index < length; index++) {
+            arrayOfBooleans[index] = getBooleanValue(values[index]);
+          }
+          return arrayOfBooleans;
+        case JavaTypeConstants.FLOAT:
+        case JavaConstants.TYPE_JAVA_LANG_FLOAT:
+          float[] arrayOfFloats = new float[length];
+          for (int index = 0; index < length; index++) {
+            arrayOfFloats[index] = values[index].floatValue().value();
+          }
+          return arrayOfFloats;
+        case JavaTypeConstants.DOUBLE:
+        case JavaConstants.TYPE_JAVA_LANG_DOUBLE:
+          double[] arrayOfDoubles = new double[length];
+          for (int index = 0; index < length; index++) {
+            arrayOfDoubles[index] = values[index].floatValue().value();
+          }
+          return arrayOfDoubles;
+        default:
+          // Array is not of a primitive type, we can create the instance via reflection
+          Object[] arrayOfObjects = (Object[]) Array.newInstance(cls, length);
+          for (int index = 0; index < length; index++) {
+            arrayOfObjects[index] = values[index].referenceValue().value();
+          }
+          return arrayOfObjects;
+      }
+    }
+  }
+}

--- a/base/src/main/java/proguard/evaluation/executor/ReflectionExecutor.java
+++ b/base/src/main/java/proguard/evaluation/executor/ReflectionExecutor.java
@@ -303,7 +303,7 @@ public abstract class ReflectionExecutor extends Executor {
         case JavaConstants.TYPE_JAVA_LANG_DOUBLE:
           double[] arrayOfDoubles = new double[length];
           for (int index = 0; index < length; index++) {
-            arrayOfDoubles[index] = values[index].floatValue().value();
+            arrayOfDoubles[index] = values[index].doubleValue().value();
           }
           return arrayOfDoubles;
         default:

--- a/base/src/main/java/proguard/evaluation/executor/StringReflectionExecutor.java
+++ b/base/src/main/java/proguard/evaluation/executor/StringReflectionExecutor.java
@@ -1,0 +1,78 @@
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2023 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proguard.evaluation.executor;
+
+import static proguard.classfile.ClassConstants.NAME_JAVA_LANG_STRING;
+import static proguard.classfile.ClassConstants.NAME_JAVA_LANG_STRING_BUFFER;
+import static proguard.classfile.ClassConstants.NAME_JAVA_LANG_STRING_BUILDER;
+
+import java.util.HashMap;
+import proguard.evaluation.executor.instancehandler.ExecutorMethodInstanceHandler;
+import proguard.evaluation.executor.matcher.ExecutorClassMatcher;
+import proguard.evaluation.value.ReferenceValue;
+import proguard.util.CollectionMatcher;
+import proguard.util.ConstantMatcher;
+import proguard.util.FixedStringMatcher;
+import proguard.util.StringMatcher;
+
+/**
+ * This {@link ReflectionExecutor} supports methods of the classes {@link String}, {@link
+ * StringBuilder} and {@link StringBuffer}.
+ */
+public class StringReflectionExecutor extends ReflectionExecutor {
+  public StringReflectionExecutor() {
+    executorMatcher =
+        new ExecutorClassMatcher(
+            new CollectionMatcher(
+                NAME_JAVA_LANG_STRING,
+                NAME_JAVA_LANG_STRING_BUILDER,
+                NAME_JAVA_LANG_STRING_BUFFER));
+    instanceHandler =
+        new ExecutorMethodInstanceHandler(
+            new HashMap<String, StringMatcher>() {
+              {
+                // Because strings are immutable, assume that string methods always return a new
+                // instance. This is technically incorrect (methods like substring may return the
+                // instance directly) but acceptable, as the evaluation compares string values
+                // and not IDs.
+                put(NAME_JAVA_LANG_STRING, new FixedStringMatcher("toString"));
+
+                // StringBuffer and StringBuilder make use of the Builder pattern - all methods
+                // which return their own type return the 'this' pointer.
+                put(NAME_JAVA_LANG_STRING_BUFFER, new ConstantMatcher(true));
+                put(NAME_JAVA_LANG_STRING_BUILDER, new ConstantMatcher(true));
+              }
+            });
+  }
+
+  @Override
+  public Object getInstanceCopyIfMutable(ReferenceValue instanceValue, String className) {
+    Object instance = instanceValue.value();
+    if (instance == null || !instanceValue.isParticular()) return null;
+    switch (className) {
+      case NAME_JAVA_LANG_STRING_BUILDER:
+        return new StringBuilder((StringBuilder) instance);
+      case NAME_JAVA_LANG_STRING_BUFFER:
+        return new StringBuffer((StringBuffer) instance);
+      case NAME_JAVA_LANG_STRING:
+        return instance;
+    }
+    return null;
+  }
+}

--- a/base/src/main/java/proguard/evaluation/executor/StringReflectionExecutor.java
+++ b/base/src/main/java/proguard/evaluation/executor/StringReflectionExecutor.java
@@ -23,6 +23,7 @@ import static proguard.classfile.ClassConstants.NAME_JAVA_LANG_STRING_BUFFER;
 import static proguard.classfile.ClassConstants.NAME_JAVA_LANG_STRING_BUILDER;
 
 import java.util.HashMap;
+import java.util.Optional;
 import proguard.evaluation.executor.instancehandler.ExecutorMethodInstanceHandler;
 import proguard.evaluation.executor.matcher.ExecutorClassMatcher;
 import proguard.evaluation.value.ReferenceValue;
@@ -62,17 +63,17 @@ public class StringReflectionExecutor extends ReflectionExecutor {
   }
 
   @Override
-  public Object getInstanceCopyIfMutable(ReferenceValue instanceValue, String className) {
+  public Optional<Object> getInstanceCopyIfMutable(ReferenceValue instanceValue, String className) {
     Object instance = instanceValue.value();
-    if (instance == null || !instanceValue.isParticular()) return null;
+    if (instance == null) return Optional.empty();
     switch (className) {
       case NAME_JAVA_LANG_STRING_BUILDER:
-        return new StringBuilder((StringBuilder) instance);
+        return Optional.of(new StringBuilder((StringBuilder) instance));
       case NAME_JAVA_LANG_STRING_BUFFER:
-        return new StringBuffer((StringBuffer) instance);
+        return Optional.of(new StringBuffer((StringBuffer) instance));
       case NAME_JAVA_LANG_STRING:
-        return instance;
+        return Optional.of(instance);
     }
-    return null;
+    return Optional.empty();
   }
 }

--- a/base/src/main/java/proguard/evaluation/executor/instancehandler/ExecutorInstanceHandler.java
+++ b/base/src/main/java/proguard/evaluation/executor/instancehandler/ExecutorInstanceHandler.java
@@ -1,0 +1,29 @@
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2023 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proguard.evaluation.executor.instancehandler;
+
+/**
+ * This interface provides a method for deciding whether a certain method call returns the calling
+ * instance.
+ */
+public interface ExecutorInstanceHandler {
+
+  /** Return whether the method always returns its calling instance. If unknown, return false. */
+  boolean returnsOwnInstance(String internalClassName, String methodName);
+}

--- a/base/src/main/java/proguard/evaluation/executor/instancehandler/ExecutorMethodInstanceHandler.java
+++ b/base/src/main/java/proguard/evaluation/executor/instancehandler/ExecutorMethodInstanceHandler.java
@@ -1,0 +1,46 @@
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2023 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proguard.evaluation.executor.instancehandler;
+
+import java.util.Map;
+import proguard.util.StringMatcher;
+
+/**
+ * This {@link ExecutorInstanceHandler} decides whether a method always returns its calling instance
+ * based on a mapping of class names to a {@link StringMatcher} for method names.
+ */
+public class ExecutorMethodInstanceHandler implements ExecutorInstanceHandler {
+  private final Map<String, StringMatcher> alwaysReturnsOwnInstance;
+
+  /**
+   * Creates an {@link ExecutorMethodInstanceHandler} using the given mapping.
+   *
+   * @param alwaysReturnsOwnInstance A mapping from class names to a matcher for methods that return
+   *     a new instance
+   */
+  public ExecutorMethodInstanceHandler(Map<String, StringMatcher> alwaysReturnsOwnInstance) {
+    this.alwaysReturnsOwnInstance = alwaysReturnsOwnInstance;
+  }
+
+  @Override
+  public boolean returnsOwnInstance(String internalClassName, String methodName) {
+    StringMatcher matcher = alwaysReturnsOwnInstance.get(internalClassName);
+    return matcher != null && matcher.matches(methodName);
+  }
+}

--- a/base/src/main/java/proguard/evaluation/executor/matcher/ExecutorClassMatcher.java
+++ b/base/src/main/java/proguard/evaluation/executor/matcher/ExecutorClassMatcher.java
@@ -1,0 +1,44 @@
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2023 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proguard.evaluation.executor.matcher;
+
+import proguard.classfile.MethodSignature;
+import proguard.evaluation.executor.Executor;
+import proguard.util.StringMatcher;
+
+/**
+ * This {@link ExecutorMatcher} matches solely based on the class name using a given {@link
+ * StringMatcher}. Use if the {@link Executor} supports a range of classes fully.
+ */
+public class ExecutorClassMatcher implements ExecutorMatcher {
+  private final StringMatcher classNameMatcher;
+
+  /**
+   * Creates a new {@link ExecutorClassMatcher} that all matches all classes that match with the
+   * given {@link StringMatcher}
+   */
+  public ExecutorClassMatcher(StringMatcher classNameMatcher) {
+    this.classNameMatcher = classNameMatcher;
+  }
+
+  @Override
+  public boolean matches(MethodSignature signature) {
+    return classNameMatcher.matches(signature.getClassName());
+  }
+}

--- a/base/src/main/java/proguard/evaluation/executor/matcher/ExecutorMatcher.java
+++ b/base/src/main/java/proguard/evaluation/executor/matcher/ExecutorMatcher.java
@@ -1,0 +1,36 @@
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2023 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proguard.evaluation.executor.matcher;
+
+import proguard.classfile.MethodSignature;
+
+/**
+ * This interface provides a method to check whether a certain method call matches with a criterion
+ * given by the implementation.
+ */
+public interface ExecutorMatcher {
+
+  /**
+   * Returns whether a method matches.
+   *
+   * @param signature The method signature.
+   * @return whether the method matches.
+   */
+  boolean matches(MethodSignature signature);
+}

--- a/base/src/main/java/proguard/evaluation/executor/matcher/ExecutorMethodAndDescriptorMatcher.java
+++ b/base/src/main/java/proguard/evaluation/executor/matcher/ExecutorMethodAndDescriptorMatcher.java
@@ -1,0 +1,81 @@
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2023 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proguard.evaluation.executor.matcher;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import proguard.classfile.MethodSignature;
+import proguard.util.OrMatcher;
+import proguard.util.StringMatcher;
+
+/**
+ * This {@link ExecutorMatcher} matches using a mapping from classes to methods to a {@link
+ * StringMatcher} for the descriptor. Use if only certain method overloads are supported.
+ */
+public class ExecutorMethodAndDescriptorMatcher implements ExecutorMatcher {
+  private final Map<String, Map<String, StringMatcher>> methodMatchers;
+
+  public ExecutorMethodAndDescriptorMatcher(
+      Map<String, Map<String, StringMatcher>> methodMatchers) {
+    this.methodMatchers = methodMatchers;
+  }
+
+  /** Builds an {@link ExecutorMethodAndDescriptorMatcher}. */
+  public static class Builder {
+    private final Map<String, Map<String, StringMatcher>> methodMatchers;
+
+    public Builder() {
+      methodMatchers = new HashMap<>();
+    }
+
+    /**
+     * Add a match to the mapping. If a matcher for class names already has an associated matcher
+     * for method names the old and the given matcher are combined using an {@link OrMatcher}.
+     *
+     * @param className The name of the class.
+     * @param methodName The name of the method.
+     * @param descriptorMatcher The matcher for the descriptor.
+     */
+    public Builder addMethodMatch(
+        String className, String methodName, StringMatcher descriptorMatcher) {
+      methodMatchers
+          .computeIfAbsent(className, name -> Collections.emptyMap())
+          .merge(methodName, descriptorMatcher, OrMatcher::new);
+      return this;
+    }
+
+    /**
+     * Build the {@link ExecutorMethodMatcher} defined by this builder.
+     *
+     * @return The built matcher.
+     */
+    public ExecutorMethodAndDescriptorMatcher build() {
+      return new ExecutorMethodAndDescriptorMatcher(methodMatchers);
+    }
+  }
+
+  @Override
+  public boolean matches(MethodSignature signature) {
+    Map<String, StringMatcher> descriptorMatchers = methodMatchers.get(signature.getClassName());
+    if (descriptorMatchers == null) return false;
+    StringMatcher descriptorMatcher = descriptorMatchers.get(signature.method);
+    return descriptorMatcher != null && descriptorMatcher.matches(signature.descriptor.toString());
+  }
+}

--- a/base/src/main/java/proguard/evaluation/executor/matcher/ExecutorMethodMatcher.java
+++ b/base/src/main/java/proguard/evaluation/executor/matcher/ExecutorMethodMatcher.java
@@ -1,0 +1,77 @@
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2023 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proguard.evaluation.executor.matcher;
+
+import java.util.HashMap;
+import java.util.Map;
+import proguard.classfile.MethodSignature;
+import proguard.evaluation.executor.Executor;
+import proguard.util.OrMatcher;
+import proguard.util.StringMatcher;
+
+/**
+ * This {@link ExecutorMatcher} matches using a mapping from a class name to a {@link StringMatcher}
+ * for matching method names. Use if the {@link Executor} handles a selection of methods from
+ * specific classes.
+ */
+public class ExecutorMethodMatcher implements ExecutorMatcher {
+  private final Map<String, StringMatcher> methodMatchers;
+
+  /**
+   * Creates an {@link ExecutorMethodMatcher} that supports methods given by a mapping from a
+   * specific class name to supported method names given by a {@link StringMatcher}
+   *
+   * @param methodMatchers The mapping of classes to supported methods.
+   */
+  public ExecutorMethodMatcher(Map<String, StringMatcher> methodMatchers) {
+    this.methodMatchers = methodMatchers;
+  }
+
+  /** Builds an {@link ExecutorMethodMatcher} */
+  public static class Builder {
+    private final Map<String, StringMatcher> methodMatchers = new HashMap<>();
+
+    /**
+     * Add a match to the mapping. If a {@link StringMatcher} is already mapped to a class name the
+     * old and the given matcher are combined using an {@link OrMatcher}.
+     *
+     * @param className The name of the class.
+     * @param methodMatcher The matcher for method names.
+     */
+    public Builder addMethodMatch(String className, StringMatcher methodMatcher) {
+      methodMatchers.merge(className, methodMatcher, OrMatcher::new);
+      return this;
+    }
+
+    /**
+     * Build the {@link ExecutorMethodMatcher} defined by this builder.
+     *
+     * @return The built matcher.
+     */
+    public ExecutorMethodMatcher build() {
+      return new ExecutorMethodMatcher(methodMatchers);
+    }
+  }
+
+  @Override
+  public boolean matches(MethodSignature methodSignature) {
+    StringMatcher matcher = methodMatchers.get(methodSignature.getClassName());
+    return matcher != null && matcher.matches(methodSignature.method);
+  }
+}

--- a/base/src/main/java/proguard/evaluation/executor/matcher/ExecutorMethodSignatureMatcher.java
+++ b/base/src/main/java/proguard/evaluation/executor/matcher/ExecutorMethodSignatureMatcher.java
@@ -29,15 +29,14 @@ import proguard.util.StringMatcher;
  * This {@link ExecutorMatcher} matches using a mapping from classes to methods to a {@link
  * StringMatcher} for the descriptor. Use if only certain method overloads are supported.
  */
-public class ExecutorMethodAndDescriptorMatcher implements ExecutorMatcher {
+public class ExecutorMethodSignatureMatcher implements ExecutorMatcher {
   private final Map<String, Map<String, StringMatcher>> methodMatchers;
 
-  public ExecutorMethodAndDescriptorMatcher(
-      Map<String, Map<String, StringMatcher>> methodMatchers) {
+  public ExecutorMethodSignatureMatcher(Map<String, Map<String, StringMatcher>> methodMatchers) {
     this.methodMatchers = methodMatchers;
   }
 
-  /** Builds an {@link ExecutorMethodAndDescriptorMatcher}. */
+  /** Builds an {@link ExecutorMethodSignatureMatcher}. */
   public static class Builder {
     private final Map<String, Map<String, StringMatcher>> methodMatchers;
 
@@ -66,8 +65,8 @@ public class ExecutorMethodAndDescriptorMatcher implements ExecutorMatcher {
      *
      * @return The built matcher.
      */
-    public ExecutorMethodAndDescriptorMatcher build() {
-      return new ExecutorMethodAndDescriptorMatcher(methodMatchers);
+    public ExecutorMethodSignatureMatcher build() {
+      return new ExecutorMethodSignatureMatcher(methodMatchers);
     }
   }
 

--- a/base/src/main/java/proguard/evaluation/value/ReflectiveMethodCallUtil.java
+++ b/base/src/main/java/proguard/evaluation/value/ReflectiveMethodCallUtil.java
@@ -30,8 +30,11 @@ import proguard.classfile.util.InternalTypeEnumeration;
  * the call fails, a RuntimeException is thrown, otherwise, a new Value is returned using the given
  * factory.
  *
+ * @deprecated This logic is now implemented in {@link
+ *     proguard.evaluation.executor.ReflectionExecutor}
  * @author Dennis Titze
  */
+@Deprecated
 public class ReflectiveMethodCallUtil {
 
   /**

--- a/base/src/test/kotlin/proguard/analysis/cpa/ExecutingInvocationUnitTest.kt
+++ b/base/src/test/kotlin/proguard/analysis/cpa/ExecutingInvocationUnitTest.kt
@@ -62,7 +62,7 @@ class ExecutingInvocationUnitTest : FreeSpec({
         val concat = MethodExecutionInfo(javaLangString, javaLangString.findMethod("concat"), null)
         "Unknown reference String length" {
             invocationUnit.executeMethod(stringExecutor, length, UnknownReferenceValue()) shouldBe UnknownIntegerValue()
-            invocationUnit.executeMethod(stringExecutor, length, UnknownIntegerValue()) shouldBe UnknownIntegerValue()
+            invocationUnit.executeMethod(stringExecutor, length, UnknownString()) shouldBe UnknownIntegerValue()
         }
 
         "Unknown String length" {

--- a/base/src/test/kotlin/proguard/analysis/cpa/jvm/domain/value/CpaValueTest.kt
+++ b/base/src/test/kotlin/proguard/analysis/cpa/jvm/domain/value/CpaValueTest.kt
@@ -2,13 +2,16 @@ package proguard.analysis.cpa.jvm.domain.value
 
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import proguard.analysis.cpa.jvm.cfa.JvmCfa
 import proguard.analysis.cpa.jvm.util.CfaUtil
 import proguard.classfile.MethodSignature
 import proguard.classfile.ProgramClass
 import proguard.classfile.Signature
+import proguard.evaluation.value.ParticularReferenceValue
 import proguard.testutils.AssemblerSource
 import proguard.testutils.ClassPoolBuilder
+import proguard.testutils.JavaSource
 
 class CpaValueTest : FreeSpec({
 
@@ -55,6 +58,41 @@ class CpaValueTest : FreeSpec({
             .single() as JvmValueAbstractState
         "Then there should be two fields in the JvmValueAbstractState" {
             last.staticFields.size shouldBe 2
+        }
+    }
+
+    "Executed method taking category2 value" - {
+        val (programClassPool, libraryClassPool) = ClassPoolBuilder.fromSource(
+            JavaSource(
+                "Test.java",
+                """
+                    import java.lang.StringBuilder;
+
+                    public class Test {
+                        public static void test() {
+                            StringBuilder builder = new StringBuilder();
+                            builder.append(1L);
+                            String s = builder.toString();
+                        }
+                    }
+                """,
+            ),
+            initialize = true,
+        )
+        val cfa: JvmCfa = CfaUtil.createInterproceduralCfa(programClassPool, libraryClassPool)
+        val clazz = programClassPool.getClass("Test") as ProgramClass
+        val mainSignature = Signature.of(clazz, clazz.findMethod("test", null)) as MethodSignature
+        val bamCpaRun = JvmValueBamCpaRun.Builder(cfa, mainSignature).setReduceHeap(true).build()
+        bamCpaRun.execute()
+        val cache = bamCpaRun.cpa.cache
+        val last = cache
+            .get(mainSignature)
+            .map { it.reachedSet.asCollection().maxBy { (it as JvmValueAbstractState).programLocation.offset } }
+            .single() as JvmValueAbstractState
+        "Correct string value" {
+            val value = last.frame.localVariables[1].value
+            value.shouldBeInstanceOf<ParticularReferenceValue>()
+            value.referenceValue().value() shouldBe "1"
         }
     }
 })

--- a/docs/md/partialevaluator.md
+++ b/docs/md/partialevaluator.md
@@ -513,7 +513,7 @@ The `ExecutingInvocationUnit` is designed to be customizable and extensible in i
 To customize an `ExecutingInvocationUnit`, use its dedicated `Builder`.
 
     :::java
-    ExecutingInvocationUnit invocationUnit = new ExecutingInvocationUnit.Builder().setAddDefaultStringReflectionExecutor(false)
+    ExecutingInvocationUnit invocationUnit = new ExecutingInvocationUnit.Builder().useDefaultStringReflectionExecutor(false)
                                                                                   .addExecutor(new MyExecutor())
                                                                                   .build(valueFactory);
 

--- a/docs/md/partialevaluator.md
+++ b/docs/md/partialevaluator.md
@@ -478,8 +478,8 @@ If the value of `s` is of interest, this can be retrieved using a `ParticularVal
 
     :::java
     ValueFactory            valueFactory     = new ParticularValueFactory(new BasicValueFactory(), 
-                                                                          new ParticularValueFactory.ReferenceValueFactory());
-    ExecutingInvocationUnit invocationUnit   = new ExecutingInvocationUnit(valueFactory);
+                                                                          new ParticularReferenceValueFactory());
+    ExecutingInvocationUnit invocationUnit   = new ExecutingInvocationUnit.Builder().build(valueFactory);
     PartialEvaluator        partialEvaluator = new PartialEvaluator(valueFactory, 
                                                                     invocationUnit, 
                                                                     false);
@@ -507,10 +507,21 @@ Instruction | Stack (before the Instruction) | v0 (before the Instruction) |
 
 The `StringBuilder` is now traced through the method, the value of the reference can be retrieved before and after each location. The value of the reference is printed in this output in the finishing brackets. The notation before the bracket is the notation of a `TypedReference` ([TypedReference](#typed))
 
+### Customization
+
+The `ExecutingInvocationUnit` is designed to be customizable and extensible in its capability to execute different methods. Therefore, it maintains a list of `Executor`s which define how a certain set of methods can be executed. Currently, only the `StringReflectionExecutor` is implemented which supports `String`, `StringBuilder`and `StringBuffer`.
+To customize an `ExecutingInvocationUnit`, use its dedicated `Builder`.
+
+    :::java
+    ExecutingInvocationUnit invocationUnit = new ExecutingInvocationUnit.Builder().setAddDefaultStringReflectionExecutor(false)
+                                                                                  .addExecutor(new MyExecutor())
+                                                                                  .build(valueFactory);
+
 ### Limitations
 
-- Only `String`, `StringBuilder`, and `StringBuffer` are currently supported.
-- The `ParticularValueFactory` keeps track of one specific value of a reference. If more values would be possible (e.g., due to a branch), the result will be an `UnknownReferenceValue`
+- Only `String`, `StringBuilder`, and `StringBuffer` are currently supported, although custom executors can be implemented.
+- The `ParticularValueFactory` keeps track of one specific value of a reference. If more values would be possible (e.g., due to a branch), the result will be an `UnknownReferenceValue`/`IdentifiedReferenceValue`
+- Independent of the specific `Executor`, `ExecutingInvocationUnit` keeps track of changes to the instance of a method. However, it does not check for changes to reference values in the parameters.
 
 ## Lifecycle
 

--- a/docs/md/releasenotes.md
+++ b/docs/md/releasenotes.md
@@ -1,3 +1,9 @@
+## Version 9.1.2
+
+### Improved
+
+- Refactor `ExecutingInvocationUnit` to be customizable using executors.
+
 ## Version 9.1.1
 
 ### Bugfixes
@@ -16,7 +22,6 @@
 - Add `IdentifiedArrayReferenceValue.generalize()` to maintain `ID` when applied to two instances with same `ID`.
 - Improve `ExecutingInvocationUnit` support to methods that transform a `String` into an array of a primitive type. 
 - Add support for customizing the way method calls are processed in taint analysis.
-- Refactor `ExecutingInvocationUnit` to be customizable using executors.
 
 ## New Code Style
 

--- a/docs/md/releasenotes.md
+++ b/docs/md/releasenotes.md
@@ -2,7 +2,12 @@
 
 ### Improved
 
-- Refactor `ExecutingInvocationUnit` to be customizable using executors.
+- Refactor `ExecutingInvocationUnit` to be customizable using executors. Improve checking whether method instance should be replaced in stack and variables
+- Support execution of methods that operate on 1D arrays of all primitive and reference types with `ReflectionExecutor`.
+
+### Bug fixes
+
+- Fix handling of category 2 values in `JvmValueTransferRelation` to work correctly with `ExecutingInvocationUnit`.
 
 ## Version 9.1.1
 

--- a/docs/md/releasenotes.md
+++ b/docs/md/releasenotes.md
@@ -16,6 +16,7 @@
 - Add `IdentifiedArrayReferenceValue.generalize()` to maintain `ID` when applied to two instances with same `ID`.
 - Improve `ExecutingInvocationUnit` support to methods that transform a `String` into an array of a primitive type. 
 - Add support for customizing the way method calls are processed in taint analysis.
+- Refactor `ExecutingInvocationUnit` to be customizable using executors.
 
 ## New Code Style
 


### PR DESCRIPTION
This refactors the old `ExecutingInvocationUnit` and sensibly separates its responsibilities into other classes.
It now maintains a configurable list of executors, each of which provides a way to obtain the result of a method within a range of supported methods.
A major advantage of this approach is that executors can handle a method however they want, e.g., avoiding reflection.

The old behavior is kept as a default, meaning a `StringReflectionExecutor` will be added unless explicitly disabled.

Aside from simplifying major parts of the logic, some improvements to the functionality have been made:
- Support all types of 1D arrays as parameters including arrays of references when using reflection (added tests for `String.join()` and `String.format()`).
- An equals check in `ExecutingInvocationUnit` makes sure that the instance of the method in stack and variables will always be updated if it changed.
