### PR TITLE
Fix attribute adder for parameter annotations

### DIFF
--- a/base/src/main/java/proguard/classfile/editor/AttributeAdder.java
+++ b/base/src/main/java/proguard/classfile/editor/AttributeAdder.java
@@ -509,7 +509,7 @@ public class AttributeAdder implements AttributeVisitor {
         new RuntimeVisibleParameterAnnotationsAttribute(
             constantAdder.addConstant(
                 clazz, runtimeVisibleParameterAnnotationsAttribute.u2attributeNameIndex),
-            0,
+            runtimeVisibleParameterAnnotationsAttribute.u1parametersCount,
             new int[runtimeVisibleParameterAnnotationsAttribute.u1parametersCount],
             parameterAnnotations);
 
@@ -538,7 +538,7 @@ public class AttributeAdder implements AttributeVisitor {
         new RuntimeInvisibleParameterAnnotationsAttribute(
             constantAdder.addConstant(
                 clazz, runtimeInvisibleParameterAnnotationsAttribute.u2attributeNameIndex),
-            0,
+            runtimeInvisibleParameterAnnotationsAttribute.u1parametersCount,
             new int[runtimeInvisibleParameterAnnotationsAttribute.u1parametersCount],
             parameterAnnotations);
 


### PR DESCRIPTION
Fixes https://github.com/Guardsquare/proguard/issues/451

The issue is described in detail there. Basically, proguard emitted a parameter annotations section, but with a length of zero, which is invalid if a function has parameters.