### PR TITLE
Avoid unnecessary linked list traversals in MethodLinker.

### DIFF
--- a/base/src/main/java/proguard/classfile/util/MethodLinker.java
+++ b/base/src/main/java/proguard/classfile/util/MethodLinker.java
@@ -19,7 +19,9 @@ package proguard.classfile.util;
 
 import static proguard.classfile.instruction.Instruction.OP_INVOKESTATIC;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import proguard.classfile.AccessConstants;
 import proguard.classfile.Clazz;
@@ -132,10 +134,17 @@ public class MethodLinker implements ClassVisitor, MemberVisitor {
    * @return The last method in the linked list.
    */
   public static Member lastMember(Member member) {
+    List<Member> chain = new ArrayList<>();
     Member lastMember = member;
     while (lastMember.getProcessingInfo() != null
         && lastMember.getProcessingInfo() instanceof Member) {
+      chain.add(lastMember);
       lastMember = (Member) lastMember.getProcessingInfo();
+    }
+
+    // Point every member in the chain directly to the last element to save time in the future
+    for (Member relatedMember : chain) {
+      relatedMember.setProcessingInfo(lastMember);
     }
 
     return lastMember;
@@ -149,6 +158,9 @@ public class MethodLinker implements ClassVisitor, MemberVisitor {
    */
   public static Processable lastProcessable(Processable processable) {
     Processable lastProcessable = processable;
+    if (lastProcessable instanceof Member) {
+      lastProcessable = lastMember((Member) lastProcessable);
+    }
     while (lastProcessable.getProcessingInfo() != null
         && lastProcessable.getProcessingInfo() instanceof Processable) {
       lastProcessable = (Processable) lastProcessable.getProcessingInfo();


### PR DESCRIPTION
The chains of method links can get surprisingly large and a huge amount of time can be wasted repeatedly traversing them.
We can cut down most of this time by flattening the chain each time we traverse it, pointing every element straight to the end.
The chains themselves are assumed to be an implementation detail of this class, in which case it's fine to flatten them at any time.
Some profiling from building one of my projects with ProGuard:
Before:
<img width="1980" alt="image" src="https://github.com/user-attachments/assets/9fb497be-b05d-4567-aac7-cc270cee8d75" />
After:
<img width="1977" alt="image" src="https://github.com/user-attachments/assets/46db76a5-9fd5-4a9e-a2d4-e3a0079ce6ed" />

I'd imagine that there are ways to avoid linked lists at all in this linking process, but this change is minimally invasive to the external API and the speedup is very large.