### PR TITLE
Update maximum supported Java version for Java 24

### DIFF
--- a/base/src/main/java/proguard/classfile/JavaVersionConstants.java
+++ b/base/src/main/java/proguard/classfile/JavaVersionConstants.java
@@ -53,4 +53,5 @@ public class JavaVersionConstants {
   public static final String CLASS_VERSION_21 = "21";
   public static final String CLASS_VERSION_22 = "22";
   public static final String CLASS_VERSION_23 = "23";
+  public static final String CLASS_VERSION_24 = "24";
 }

--- a/base/src/main/java/proguard/classfile/VersionConstants.java
+++ b/base/src/main/java/proguard/classfile/VersionConstants.java
@@ -71,6 +71,8 @@ public class VersionConstants {
   public static final int CLASS_VERSION_22_MINOR = 0;
   public static final int CLASS_VERSION_23_MAJOR = 67;
   public static final int CLASS_VERSION_23_MINOR = 0;
+  public static final int CLASS_VERSION_24_MAJOR = 68;
+  public static final int CLASS_VERSION_24_MINOR = 0;
   public static final int PREVIEW_VERSION_MINOR = 65535;
 
   public static final int CLASS_VERSION_1_0 =
@@ -119,7 +121,9 @@ public class VersionConstants {
       (CLASS_VERSION_22_MAJOR << 16) | CLASS_VERSION_22_MINOR;
   public static final int CLASS_VERSION_23 =
       (CLASS_VERSION_23_MAJOR << 16) | CLASS_VERSION_23_MINOR;
+  public static final int CLASS_VERSION_24 =
+      (CLASS_VERSION_24_MAJOR << 16) | CLASS_VERSION_24_MINOR;
 
   public static final int MAX_SUPPORTED_VERSION =
-      (CLASS_VERSION_23_MAJOR << 16) | PREVIEW_VERSION_MINOR;
+      (CLASS_VERSION_24_MAJOR << 16) | PREVIEW_VERSION_MINOR;
 }

--- a/base/src/main/java/proguard/classfile/util/ClassUtil.java
+++ b/base/src/main/java/proguard/classfile/util/ClassUtil.java
@@ -148,6 +148,8 @@ public class ClassUtil {
         return VersionConstants.CLASS_VERSION_22;
       case JavaVersionConstants.CLASS_VERSION_23:
         return VersionConstants.CLASS_VERSION_23;
+      case JavaVersionConstants.CLASS_VERSION_24:
+        return VersionConstants.CLASS_VERSION_24;
     }
     return 0;
   }
@@ -206,6 +208,8 @@ public class ClassUtil {
         return JavaVersionConstants.CLASS_VERSION_22;
       case VersionConstants.CLASS_VERSION_23:
         return JavaVersionConstants.CLASS_VERSION_23;
+      case VersionConstants.CLASS_VERSION_24:
+        return JavaVersionConstants.CLASS_VERSION_24;
       default:
         return null;
     }

--- a/docs/md/releasenotes.md
+++ b/docs/md/releasenotes.md
@@ -1,5 +1,9 @@
 ## Version 9.1.10
 
+### Java support
+
+- Update maximum supported Java class version to 68.65535 (Java 24).
+
 ## Version 9.1.9
 
 ### Improved


### PR DESCRIPTION
Updates the maximum supported class file version for Java 24.

There does not appear to be any changes to bytecode/class file format that require any further changes beyond the version bump in ProGuard(CORE). See https://openjdk.org/projects/jdk/24/

ProGuard issue: https://github.com/Guardsquare/proguard/issues/458