### PR TITLE
Correctly rename InvokeDynamic method references during obfuscation

### DIFF
--- a/base/src/main/java/proguard/classfile/constant/InvokeDynamicConstant.java
+++ b/base/src/main/java/proguard/classfile/constant/InvokeDynamicConstant.java
@@ -45,8 +45,8 @@ public class InvokeDynamicConstant extends Constant {
   public Clazz referencedClass;
 
   /**
-   * An extra field pointing to the Member referenced by this InvokeDynamic. This field is
-   * populated by the <code>{@link proguard.classfile.util.LambdaReferenceInitializer}</code>.
+   * An extra field pointing to the Member referenced by this InvokeDynamic. This field is populated
+   * by the <code>{@link proguard.classfile.util.LambdaReferenceInitializer}</code>.
    */
   public Member referencedMember;
 

--- a/base/src/main/java/proguard/classfile/editor/MemberReferenceFixer.java
+++ b/base/src/main/java/proguard/classfile/editor/MemberReferenceFixer.java
@@ -200,25 +200,23 @@ public class MemberReferenceFixer
   }
 
   @Override
-  public void visitInvokeDynamicConstant(Clazz clazz, InvokeDynamicConstant invokeDynamicConstant)
-  {
+  public void visitInvokeDynamicConstant(Clazz clazz, InvokeDynamicConstant invokeDynamicConstant) {
     // Do we know the referenced member?
-    if (invokeDynamicConstant.referencedMember != null)
-    {
-      Clazz  referencedClass  = invokeDynamicConstant.referencedClass;
+    if (invokeDynamicConstant.referencedMember != null) {
+      Clazz referencedClass = invokeDynamicConstant.referencedClass;
       Member referencedMember = invokeDynamicConstant.referencedMember;
 
       // Does it have a new name?
-      String newName     = referencedMember.getName(referencedClass);
+      String newName = referencedMember.getName(referencedClass);
       String currentName = invokeDynamicConstant.getName(clazz);
 
-      if (!currentName.equals(newName))
-      {
+      if (!currentName.equals(newName)) {
         String currentDescriptor = invokeDynamicConstant.getType(clazz);
 
         // Update the name and type index.
         invokeDynamicConstant.u2nameAndTypeIndex =
-                new ConstantPoolEditor((ProgramClass)clazz).addNameAndTypeConstant(newName, currentDescriptor);
+            new ConstantPoolEditor((ProgramClass) clazz)
+                .addNameAndTypeConstant(newName, currentDescriptor);
       }
     }
   }

--- a/base/src/main/java/proguard/classfile/util/LambdaReferenceInitializer.java
+++ b/base/src/main/java/proguard/classfile/util/LambdaReferenceInitializer.java
@@ -27,18 +27,15 @@ import proguard.classfile.constant.visitor.ConstantVisitor;
 import proguard.classfile.visitor.ClassVisitor;
 
 /**
- * This {@link ClassVisitor} initializes the references of {@link InvokeDynamicConstant}s
- * that represent lambda expressions. More specifically, it links the constants to the
- * actual functional interface methods they target in the program class pool or in the
- * library class pool.
+ * This {@link ClassVisitor} initializes the references of {@link InvokeDynamicConstant}s that
+ * represent lambda expressions. More specifically, it links the constants to the actual functional
+ * interface methods they target in the program class pool or in the library class pool.
  *
  * <p>The class hierarchy must be initialized before using this visitor.
  *
  * @author ShortyDev
  */
-public class LambdaReferenceInitializer
-        implements ClassVisitor,
-        ConstantVisitor {
+public class LambdaReferenceInitializer implements ClassVisitor, ConstantVisitor {
   private final ClassPool programClassPool;
   private final ClassPool libraryClassPool;
 
@@ -49,8 +46,7 @@ public class LambdaReferenceInitializer
 
   // Implementations for ClassVisitor.
   @Override
-  public void visitAnyClass(Clazz clazz) {
-  }
+  public void visitAnyClass(Clazz clazz) {}
 
   @Override
   public void visitProgramClass(ProgramClass programClass) {
@@ -59,8 +55,7 @@ public class LambdaReferenceInitializer
 
   // Implementations for ConstantVisitor.
   @Override
-  public void visitAnyConstant(Clazz clazz, Constant constant) {
-  }
+  public void visitAnyConstant(Clazz clazz, Constant constant) {}
 
   @Override
   public void visitInvokeDynamicConstant(Clazz clazz, InvokeDynamicConstant invokeDynamicConstant) {


### PR DESCRIPTION
This PR enables ProGuard to track and update the method name in invokedynamic instructions (Lambdas) when the target Functional Interface method is renamed. Previously, only the descriptor type was updated, leading to a mismatch between the instruction name and the actual interface method.

Changes:
- InvokeDynamicConstant: Added referencedClass and referencedMember fields to store the resolved Functional Interface method.
- LambdaReferenceInitializer: Introduced a new visitor that links invokedynamic constants to their corresponding interface members.
- MemberReferenceFixer: Added logic to detect if the linked member has been renamed and update the NameAndType constant in the pool accordingly.

Relevant issue:
https://github.com/Guardsquare/proguard/issues/512