### PR TITLE
Add KotlinAliasReferenceFixer to fix Kotlin type alias references after renaming

### DIFF
--- a/base/src/main/java/proguard/classfile/editor/ClassReferenceFixer.java
+++ b/base/src/main/java/proguard/classfile/editor/ClassReferenceFixer.java
@@ -773,7 +773,7 @@ public class ClassReferenceFixer
         kotlinTypeMetadata.className = kotlinTypeMetadata.referencedClass.getName();
       }
 
-      // We fix aliasName using KotlinAliasReferenceFixer after ClassReferenceFixer is finished.
+      // aliasName is fixed by KotlinAliasReferenceFixer, run after ClassReferenceFixer.
 
       kotlinTypeMetadata.annotationsAccept(clazz, this);
       kotlinTypeMetadata.typeArgumentsAccept(clazz, this);

--- a/base/src/main/java/proguard/classfile/editor/KotlinAliasReferenceFixer.java
+++ b/base/src/main/java/proguard/classfile/editor/KotlinAliasReferenceFixer.java
@@ -1,0 +1,80 @@
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2026 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package proguard.classfile.editor;
+
+import proguard.classfile.Clazz;
+import proguard.classfile.kotlin.KotlinClassKindMetadata;
+import proguard.classfile.kotlin.KotlinDeclarationContainerMetadata;
+import proguard.classfile.kotlin.KotlinTypeAliasMetadata;
+import proguard.classfile.kotlin.KotlinTypeMetadata;
+import proguard.classfile.kotlin.visitor.AllTypeVisitor;
+import proguard.classfile.kotlin.visitor.KotlinTypeVisitor;
+import proguard.classfile.util.ClassUtil;
+import proguard.classfile.visitor.ClassVisitor;
+
+/**
+ * This {@link ClassVisitor} fixes the {@code aliasName} of Kotlin types that reference a type alias
+ * whose declaration container has been renamed.
+ *
+ * <p>{@link ClassReferenceFixer} re-derives a type's {@code className} from its referenced class,
+ * but it leaves {@code aliasName} alone, because {@code aliasName} is a plain string naming the
+ * alias's <i>declaration site</i> rather than a reference that {@link ClassReferenceFixer}
+ * resolves. Run this fixer over the program class pool <b>after</b> {@link ClassReferenceFixer} (so
+ * the declaration containers already carry their new names) to keep those strings consistent with
+ * the renamed declarations.
+ *
+ * <p>The recorded format matches what {@link proguard.classfile.util.ClassReferenceInitializer}
+ * parses back: an alias declared in a class is {@code <declaring class>.<simple name>}; one
+ * declared in a file facade (or multi-file part) is {@code <facade package>/<simple name>}. Both
+ * pieces are read from the post-rename declaration container, so the rewrite holds under any
+ * renaming, including a move to another package. An unresolved reference (no referenced type alias)
+ * is left untouched, mirroring how {@link ClassReferenceFixer} skips unresolved references.
+ *
+ * @see ClassReferenceFixer
+ */
+public class KotlinAliasReferenceFixer implements ClassVisitor, KotlinTypeVisitor {
+
+  // Implementations for ClassVisitor.
+
+  @Override
+  public void visitAnyClass(Clazz clazz) {
+    clazz.kotlinMetadataAccept(new AllTypeVisitor(this));
+  }
+
+  // Implementations for KotlinTypeVisitor.
+
+  @Override
+  public void visitAnyType(Clazz clazz, KotlinTypeMetadata kotlinTypeMetadata) {
+    if (kotlinTypeMetadata.aliasName == null) {
+      return;
+    }
+
+    KotlinTypeAliasMetadata referencedTypeAlias = kotlinTypeMetadata.referencedTypeAlias;
+    if (referencedTypeAlias == null || referencedTypeAlias.referencedDeclarationContainer == null) {
+      return;
+    }
+
+    KotlinDeclarationContainerMetadata container =
+        referencedTypeAlias.referencedDeclarationContainer;
+
+    kotlinTypeMetadata.aliasName =
+        container instanceof KotlinClassKindMetadata
+            ? ((KotlinClassKindMetadata) container).className + "." + referencedTypeAlias.name
+            : ClassUtil.internalPackagePrefix(container.ownerClassName) + referencedTypeAlias.name;
+  }
+}

--- a/base/src/test/kotlin/proguard/classfile/editor/KotlinAliasReferenceFixerTest.kt
+++ b/base/src/test/kotlin/proguard/classfile/editor/KotlinAliasReferenceFixerTest.kt
@@ -1,0 +1,60 @@
+package proguard.classfile.editor
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import proguard.classfile.ClassPool
+import proguard.classfile.Clazz
+import proguard.classfile.kotlin.KotlinTypeMetadata
+import proguard.classfile.kotlin.visitor.AllTypeVisitor
+import proguard.classfile.kotlin.visitor.KotlinTypeVisitor
+import proguard.classfile.kotlin.visitor.ReferencedKotlinMetadataVisitor
+import proguard.classfile.util.ClassRenamer
+import proguard.testutils.ClassPoolBuilder
+import proguard.testutils.KotlinSource
+
+class KotlinAliasReferenceFixerTest : FunSpec({
+
+    test("aliasName follows its declaring file facade when the facade is renamed to another package") {
+        val (programClassPool, _) = ClassPoolBuilder.fromSource(
+            KotlinSource(
+                "Foo.kt",
+                """
+                package a.b
+
+                typealias Alias = String
+
+                val usage: Alias = ""
+                """.trimIndent(),
+            ),
+        )
+
+        // Move the file facade that declares the alias to a different package.
+        programClassPool.classAccept("a/b/FooKt", ClassRenamer { "x/y/FooKt" })
+
+        // ClassReferenceFixer fixes className but, by design, leaves aliasName.
+        programClassPool.classesAccept(ClassReferenceFixer(false))
+        programClassPool.classesAccept(KotlinAliasReferenceFixer())
+
+        aliasNamesIn(programClassPool).let { aliasNames ->
+            aliasNames shouldContain "x/y/Alias"
+            aliasNames shouldNotContain "a/b/Alias"
+        }
+    }
+})
+
+private fun aliasNamesIn(programClassPool: ClassPool): List<String> {
+    val aliasNames = mutableListOf<String>()
+    programClassPool.classesAccept(
+        ReferencedKotlinMetadataVisitor(
+            AllTypeVisitor(
+                object : KotlinTypeVisitor {
+                    override fun visitAnyType(clazz: Clazz, type: KotlinTypeMetadata) {
+                        type.aliasName?.let { aliasNames += it }
+                    }
+                },
+            ),
+        ),
+    )
+    return aliasNames
+}

--- a/base/src/test/kotlin/proguard/classfile/editor/KotlinAliasReferenceFixerTest.kt
+++ b/base/src/test/kotlin/proguard/classfile/editor/KotlinAliasReferenceFixerTest.kt
@@ -41,6 +41,35 @@ class KotlinAliasReferenceFixerTest : FunSpec({
             aliasNames shouldNotContain "a/b/Alias"
         }
     }
+
+    test("aliasName follows its declaring class when the class is renamed to another package") {
+        val (programClassPool, _) = ClassPoolBuilder.fromSource(
+            KotlinSource(
+                "Foo.kt",
+                """
+                package a.b
+
+                class Foo {
+                    typealias Alias = String
+
+                    val usage: Alias = ""
+                }
+                """.trimIndent(),
+            ),
+        )
+
+        // Rename the class that declares the alias.
+        programClassPool.classAccept("a/b/Foo", ClassRenamer { "x/Bar" })
+
+        // ClassReferenceFixer fixes className but, by design, leaves aliasName.
+        programClassPool.classesAccept(ClassReferenceFixer(false))
+        programClassPool.classesAccept(KotlinAliasReferenceFixer())
+
+        aliasNamesIn(programClassPool).let { aliasNames ->
+            aliasNames shouldContain "x/Bar.Alias"
+            aliasNames shouldNotContain "a/b/Foo.Alias"
+        }
+    }
 })
 
 private fun aliasNamesIn(programClassPool: ClassPool): List<String> {

--- a/docs/md/releasenotes.md
+++ b/docs/md/releasenotes.md
@@ -6,6 +6,7 @@
 
 ### API improvements
 
+- Add `KotlinAliasReferenceFixer` to update Kotlin type alias references (`aliasName`) after their declaration container is renamed. Run it after `ClassReferenceFixer`.
 - `MemberRemover` will now throw an exception if you attempt to collect a member from a class for removal while you're still collecting members from another class. You must commit member removal for the current class before collecting members from another class.  
 
 ### API changes


### PR DESCRIPTION
`ClassReferenceFixer`'s `KotlinReferenceFixer.visitAnyType` re-derives a type's `className` from its `referencedClass` but leaves `aliasName` alone, with a comment deferring to a `KotlinAliasReferenceFixer` — which didn't exist anywhere; the comment was its only mention.

So after a rename, a Kotlin type that references a `typealias` keeps an `aliasName` pointing at the alias's old declaration site (`<class>.<name>`, or `<package>/<name>` for a facade — the string `ClassReferenceInitializer` parses back). When the declaring class or file facade is renamed, especially across packages, every reference to its aliases is left dangling. `TypeIntegrity` only null-checks `referencedTypeAlias`, so the asserter doesn't flag the stale text.

This adds the missing `KotlinAliasReferenceFixer` as a `ClassVisitor` you run over the program class pool after `ClassReferenceFixer`. It rewrites each `aliasName` from its `referencedTypeAlias`' post-rename declaration container (both the class- and facade-declared formats), and leaves unresolved references untouched, mirroring how `ClassReferenceFixer` skips them. I also pointed the existing comment at the now-real class.

`KotlinAliasReferenceFixerTest` declares a `typealias` in a file facade, renames the facade to another package, runs `ClassReferenceFixer` then the new fixer, and asserts the using type's `aliasName` moves with it (`a/b/Alias` → `x/y/Alias`).
