### PR TITLE
Guard against unresolved Kotlin metadata references in ClassReferenceFixer

### DIFF
--- a/base/src/main/java/proguard/classfile/editor/ClassReferenceFixer.java
+++ b/base/src/main/java/proguard/classfile/editor/ClassReferenceFixer.java
@@ -591,7 +591,11 @@ public class ClassReferenceFixer
       }
 
       kotlinClassKindMetadata.enumEntries.forEach(
-          enumEntry -> enumEntry.name = enumEntry.referencedEnumEntry.getName(clazz));
+          enumEntry -> {
+            if (enumEntry.referencedEnumEntry != null) {
+              enumEntry.name = enumEntry.referencedEnumEntry.getName(clazz);
+            }
+          });
 
       for (int k = 0; k < kotlinClassKindMetadata.nestedClassNames.size(); k++) {
         kotlinClassKindMetadata.nestedClassNames.set(
@@ -662,7 +666,9 @@ public class ClassReferenceFixer
         KotlinDeclarationContainerMetadata kotlinDeclarationContainerMetadata,
         KotlinPropertyMetadata kotlinPropertyMetadata) {
       ProgramClass programClass = (ProgramClass) clazz;
-      if (kotlinPropertyMetadata.backingFieldSignature != null) {
+      if (kotlinPropertyMetadata.backingFieldSignature != null
+          && kotlinPropertyMetadata.referencedBackingFieldClass != null
+          && kotlinPropertyMetadata.referencedBackingField != null) {
         Clazz backingFieldClass = kotlinPropertyMetadata.referencedBackingFieldClass;
         Field backingField = kotlinPropertyMetadata.referencedBackingField;
         kotlinPropertyMetadata.backingFieldSignature =
@@ -722,7 +728,9 @@ public class ClassReferenceFixer
       }
 
       // Fix the JVM signatures.
-      if (kotlinFunctionMetadata.jvmSignature != null) {
+      if (kotlinFunctionMetadata.jvmSignature != null
+          && kotlinFunctionMetadata.referencedMethodClass != null
+          && kotlinFunctionMetadata.referencedMethod != null) {
         Clazz jvmClass = kotlinFunctionMetadata.referencedMethodClass;
         Method jvmMethod = kotlinFunctionMetadata.referencedMethod;
         kotlinFunctionMetadata.jvmSignature = new MethodSignature(jvmClass, jvmMethod);
@@ -737,14 +745,17 @@ public class ClassReferenceFixer
       kotlinFunctionMetadata.contractsAccept(clazz, kotlinMetadata, new AllTypeVisitor(this));
       kotlinFunctionMetadata.annotationsAccept(clazz, this);
 
-      String newFunctionName =
-          newKotlinFunctionName(
-              kotlinFunctionMetadata.name,
-              kotlinFunctionMetadata.referencedMethod.getName(
-                  kotlinFunctionMetadata.referencedMethodClass));
+      if (kotlinFunctionMetadata.referencedMethod != null
+          && kotlinFunctionMetadata.referencedMethodClass != null) {
+        String newFunctionName =
+            newKotlinFunctionName(
+                kotlinFunctionMetadata.name,
+                kotlinFunctionMetadata.referencedMethod.getName(
+                    kotlinFunctionMetadata.referencedMethodClass));
 
-      if (!kotlinFunctionMetadata.name.equals(newFunctionName)) {
-        kotlinFunctionMetadata.name = newFunctionName;
+        if (!kotlinFunctionMetadata.name.equals(newFunctionName)) {
+          kotlinFunctionMetadata.name = newFunctionName;
+        }
       }
     }
 
@@ -754,7 +765,8 @@ public class ClassReferenceFixer
         Clazz clazz,
         KotlinClassKindMetadata kotlinClassKindMetadata,
         KotlinConstructorMetadata kotlinConstructorMetadata) {
-      if (kotlinConstructorMetadata.jvmSignature != null) {
+      if (kotlinConstructorMetadata.jvmSignature != null
+          && kotlinConstructorMetadata.referencedMethod != null) {
         Method jvmMethod = kotlinConstructorMetadata.referencedMethod;
         kotlinConstructorMetadata.jvmSignature = new MethodSignature(clazz, jvmMethod);
       }
@@ -766,7 +778,7 @@ public class ClassReferenceFixer
     // Implementations for KotlinTypeVisitor.
     @Override
     public void visitAnyType(Clazz clazz, KotlinTypeMetadata kotlinTypeMetadata) {
-      if (kotlinTypeMetadata.className != null) {
+      if (kotlinTypeMetadata.className != null && kotlinTypeMetadata.referencedClass != null) {
         kotlinTypeMetadata.className = kotlinTypeMetadata.referencedClass.getName();
       }
 
@@ -898,8 +910,11 @@ public class ClassReferenceFixer
         KotlinAnnotation annotation,
         KotlinAnnotationArgument argument,
         Value value) {
-      argument.name =
-          argument.referencedAnnotationMethod.getName(argument.referencedAnnotationMethodClass);
+      if (argument.referencedAnnotationMethod != null
+          && argument.referencedAnnotationMethodClass != null) {
+        argument.name =
+            argument.referencedAnnotationMethod.getName(argument.referencedAnnotationMethodClass);
+      }
     }
 
     @Override
@@ -911,7 +926,9 @@ public class ClassReferenceFixer
         KotlinAnnotationArgument.ClassValue value) {
       this.visitAnyArgument(clazz, annotatable, annotation, argument, value);
 
-      value.className = value.referencedClass.getName();
+      if (value.referencedClass != null) {
+        value.className = value.referencedClass.getName();
+      }
     }
 
     @Override
@@ -923,7 +940,9 @@ public class ClassReferenceFixer
         KotlinAnnotationArgument.EnumValue value) {
       this.visitAnyArgument(clazz, annotatable, annotation, argument, value);
 
-      value.className = value.referencedClass.getName();
+      if (value.referencedClass != null) {
+        value.className = value.referencedClass.getName();
+      }
     }
   }
 
@@ -1099,6 +1118,12 @@ public class ClassReferenceFixer
       MethodSignature oldSignature) {
     if (oldSignature == null) {
       return null;
+    }
+
+    // If the referenced method didn't resolve (e.g. an incomplete class pool), leave the existing
+    // signature as-is rather than dereferencing a null reference.
+    if (referencedMethodClass == null || referencedMethod == null) {
+      return oldSignature;
     }
 
     MethodSignature newSignature = new MethodSignature(referencedMethodClass, referencedMethod);

--- a/base/src/test/kotlin/proguard/classfile/editor/ClassReferenceFixerDanglingReferenceTest.kt
+++ b/base/src/test/kotlin/proguard/classfile/editor/ClassReferenceFixerDanglingReferenceTest.kt
@@ -58,4 +58,33 @@ class ClassReferenceFixerDanglingReferenceTest : FunSpec({
             programClassPool.classesAccept(ClassReferenceFixer(false))
         }
     }
+
+    test("A dangling Kotlin annotation-argument reference does not crash the ClassReferenceFixer") {
+        val (programClassPool, libraryClassPool) = ClassPoolBuilder.fromSource(
+            KotlinSource(
+                "Holder.kt",
+                """
+                import kotlin.reflect.KClass
+
+                @Target(AnnotationTarget.TYPE)
+                annotation class Anno(val cls: KClass<*>)
+
+                class Referenced
+
+                class Holder {
+                    val annotated: @Anno(Referenced::class) String = ""
+                }
+                """.trimIndent(),
+            ),
+        )
+
+        // Simulate an incomplete class pool: remove the class referenced by the annotation argument
+        // and reinitialize so the KClass argument's referencedClass is left null.
+        programClassPool.removeClass("Referenced")
+        programClassPool.classesAccept(ClassReferenceInitializer(programClassPool, libraryClassPool))
+
+        shouldNotThrowAny {
+            programClassPool.classesAccept(ClassReferenceFixer(false))
+        }
+    }
 })

--- a/base/src/test/kotlin/proguard/classfile/editor/ClassReferenceFixerDanglingReferenceTest.kt
+++ b/base/src/test/kotlin/proguard/classfile/editor/ClassReferenceFixerDanglingReferenceTest.kt
@@ -1,0 +1,61 @@
+/*
+ * ProGuardCORE -- library to process Java bytecode.
+ *
+ * Copyright (c) 2002-2021 Guardsquare NV
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proguard.classfile.editor
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.FunSpec
+import proguard.classfile.util.ClassReferenceInitializer
+import proguard.testutils.ClassPoolBuilder
+import proguard.testutils.KotlinSource
+
+/**
+ * Regression tests for https://github.com/Guardsquare/proguard-core/issues/174.
+ *
+ * When the class pool is incomplete -- e.g. a class referenced only from `@Metadata` isn't on the
+ * classpath -- [ClassReferenceInitializer] leaves the matching `referenced*` field null.
+ * [ClassReferenceFixer] must degrade gracefully in that case rather than throwing a
+ * [NullPointerException] while fixing the Kotlin metadata.
+ */
+class ClassReferenceFixerDanglingReferenceTest : FunSpec({
+
+    test("A dangling Kotlin type reference does not crash the ClassReferenceFixer") {
+        val (programClassPool, libraryClassPool) = ClassPoolBuilder.fromSource(
+            KotlinSource(
+                "Holder.kt",
+                """
+                class Referenced
+
+                class Holder {
+                    val held: Referenced = Referenced()
+                    fun make(): Referenced = Referenced()
+                }
+                """.trimIndent(),
+            ),
+        )
+
+        // Simulate an incomplete class pool: remove the referenced class and reinitialize so
+        // Holder's Kotlin type metadata is left with null referencedClass fields.
+        programClassPool.removeClass("Referenced")
+        programClassPool.classesAccept(ClassReferenceInitializer(programClassPool, libraryClassPool))
+
+        shouldNotThrowAny {
+            programClassPool.classesAccept(ClassReferenceFixer(false))
+        }
+    }
+})

--- a/docs/md/releasenotes.md
+++ b/docs/md/releasenotes.md
@@ -3,6 +3,7 @@
 ### Bugfixes
 
 - Fix reference initialization for type aliases defined in file facades with a custom JvmPackageName.
+- Fix `NullPointerException` in `ClassReferenceFixer` when a Kotlin metadata reference left unresolved by an incomplete class pool is dereferenced.
 - Fix PKCS7OutputStream incorrectly handling escaped quotes certificates.
 
 ### Kotlin support


### PR DESCRIPTION
## Summary

`ClassReferenceFixer`'s `KotlinReferenceFixer` dereferenced several `referenced*` fields without a null check. When the class pool is incomplete, e.g. a class referenced only from `@Metadata` that isn't on the classpath, `ClassReferenceInitializer` leaves the matching `referenced*` field null, and the fixer threw a `NullPointerException` instead of leaving the reference as-is.

This adds the same null guard the annotation path (`visitAnyAnnotation`) already uses to every remaining dereference in the visitor.

Fixes #174.

## Sites guarded

Beyond the spots listed in the issue, the sweep covers every sibling that shares the root cause:

| Site | Field(s) |
| --- | --- |
| `visitKotlinClassMetadata` | `enumEntry.referencedEnumEntry` (enum entry names) |
| `visitAnyFunction` | `referencedMethod` / `referencedMethodClass` (JVM signature + function name) |
| `visitConstructor` | `referencedMethod` (JVM signature) |
| `visitAnyType` | `referencedClass` (the guard was on `className`, not the `referencedClass` it dereferences) |
| `visitAnyArgument` | `referencedAnnotationMethod` / `referencedAnnotationClass` |
| `visitClassArgument` / `visitEnumArgument` | `value.referencedClass` |
| `visitAnyProperty` | `referencedBackingField(Class)` (backing-field signature) |
| `fixPropertyMethod` | `referencedMethodClass` / `referencedMethod` (accessor + synthetic method signatures) |

The `newClassName`-based paths (nested classes, sealed subclasses, multi-file facade parts) were already null-safe, since that helper returns the name unchanged when the referenced class is null.

## Behavior

In every guarded case the fixer now leaves the reference as-is when it didn't resolve, matching the existing `visitAnyAnnotation` behavior. The guards only add a skip when a `referenced*` field is null, which previously threw; the resolved case is unchanged (the full existing `:proguard-core` suite still passes).

## Tests

`ClassReferenceFixerDanglingReferenceTest` reproduces the incomplete-classpath scenario by removing a referenced class, reinitializing, then running the fixer:

- a dangling type reference (`visitAnyType`)
- a dangling annotation-argument reference (`visitClassArgument`)

Both were verified to throw a `NullPointerException` before the fix and pass after.
