### PR TITLE
Resolve suspend lambda referencedMethod to invokeSuspend in ClassReferenceInitializer

### DIFF
--- a/base/src/main/java/proguard/classfile/kotlin/KotlinConstants.java
+++ b/base/src/main/java/proguard/classfile/kotlin/KotlinConstants.java
@@ -37,6 +37,10 @@ public class KotlinConstants {
 
   public static final String METHOD_NAME_LAMBDA_INVOKE = "invoke";
 
+  public static final String METHOD_NAME_LAMBDA_INVOKE_SUSPEND = "invokeSuspend";
+  public static final String METHOD_TYPE_LAMBDA_INVOKE_SUSPEND =
+      "(Ljava/lang/Object;)Ljava/lang/Object;";
+
   public static final String NAME_KOTLIN_METADATA = "kotlin/Metadata";
   public static final String TYPE_KOTLIN_METADATA = "Lkotlin/Metadata;";
   public static final String NAME_KOTLIN_ANY = "kotlin/Any";

--- a/base/src/main/java/proguard/classfile/util/ClassReferenceInitializer.java
+++ b/base/src/main/java/proguard/classfile/util/ClassReferenceInitializer.java
@@ -24,6 +24,8 @@ import static proguard.classfile.kotlin.KotlinConstants.DEFAULT_IMPLEMENTATIONS_
 import static proguard.classfile.kotlin.KotlinConstants.DEFAULT_METHOD_SUFFIX;
 import static proguard.classfile.kotlin.KotlinConstants.FUNCTION_NAME_ANONYMOUS;
 import static proguard.classfile.kotlin.KotlinConstants.METHOD_NAME_LAMBDA_INVOKE;
+import static proguard.classfile.kotlin.KotlinConstants.METHOD_NAME_LAMBDA_INVOKE_SUSPEND;
+import static proguard.classfile.kotlin.KotlinConstants.METHOD_TYPE_LAMBDA_INVOKE_SUSPEND;
 
 import java.util.Collections;
 import java.util.stream.Collectors;
@@ -965,8 +967,10 @@ public class ClassReferenceInitializer
       kotlinFunctionMetadata.referencedMethodClass = clazz;
 
       if (kotlinFunctionMetadata.jvmSignature != null) {
+        boolean isAnonymous =
+            FUNCTION_NAME_ANONYMOUS.equals(kotlinFunctionMetadata.jvmSignature.method);
         String method =
-            !FUNCTION_NAME_ANONYMOUS.equals(kotlinFunctionMetadata.jvmSignature.method)
+            !isAnonymous
                 ? kotlinFunctionMetadata.jvmSignature.method
                 :
                 // T16483: In some cases, the jvmSignature erroneously contains the name <anonymous>
@@ -978,6 +982,19 @@ public class ClassReferenceInitializer
                 kotlinFunctionMetadata.referencedMethodClass,
                 method,
                 kotlinFunctionMetadata.jvmSignature.descriptor.toString());
+
+        if (kotlinFunctionMetadata.referencedMethod == null && isAnonymous) {
+          // A coroutine suspend lambda's body is compiled into SuspendLambda.invokeSuspend
+          // rather than invoke, and its jvmSignature carries the Kotlin-level descriptor, so the
+          // invoke lookup above misses and leaves referencedMethod null (which later NPEs the
+          // ClassReferenceFixer). Fall back to the fixed invokeSuspend(Object)Object signature;
+          // only SuspendLambda subclasses declare it, so this cannot mismatch a plain lambda.
+          kotlinFunctionMetadata.referencedMethod =
+              strictMemberFinder.findMethod(
+                  kotlinFunctionMetadata.referencedMethodClass,
+                  METHOD_NAME_LAMBDA_INVOKE_SUSPEND,
+                  METHOD_TYPE_LAMBDA_INVOKE_SUSPEND);
+        }
       }
 
       if (kotlinFunctionMetadata.lambdaClassOriginName != null) {

--- a/base/src/test/kotlin/proguard/classfile/editor/ClassReferenceFixerTest.kt
+++ b/base/src/test/kotlin/proguard/classfile/editor/ClassReferenceFixerTest.kt
@@ -18,6 +18,7 @@
 
 package proguard.classfile.editor
 
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -462,6 +463,53 @@ class ClassReferenceFixerTest : FunSpec({
                         },
                     )
                 }
+            }
+        }
+    }
+
+    context("Given a Kotlin coroutine suspend lambda") {
+        // A suspend lambda compiles to a SuspendLambda subclass whose body lives in
+        // invokeSuspend(Object)Object, not invoke, so ClassReferenceInitializer must resolve
+        // referencedMethod to invokeSuspend. Otherwise it stays null and NPEs the fixer (#175).
+        val (programClassPool, _) = ClassPoolBuilder.fromSource(
+            KotlinSource(
+                "Test.kt",
+                """
+                fun runIt(block: suspend () -> Unit) { }
+                fun caller() {
+                    runIt { println("hello") }
+                }
+                """.trimIndent(),
+            ),
+        )
+
+        test("Then its anonymous function metadata resolves to invokeSuspend") {
+            var referencedMethodName: String? = null
+            programClassPool.classesAccept(
+                ReferencedKotlinMetadataVisitor(
+                    AllFunctionVisitor(
+                        object : KotlinFunctionVisitor {
+                            override fun visitAnyFunction(
+                                clazz: Clazz,
+                                metadata: proguard.classfile.kotlin.KotlinMetadata,
+                                function: proguard.classfile.kotlin.KotlinFunctionMetadata,
+                            ) {
+                                if (function.jvmSignature?.method != "<anonymous>") return
+                                function.referencedMethod shouldNotBe null
+                                referencedMethodName =
+                                    function.referencedMethod.getName(function.referencedMethodClass)
+                            }
+                        },
+                    ),
+                ),
+            )
+
+            referencedMethodName shouldBe "invokeSuspend"
+        }
+
+        test("Then applying the ClassReferenceFixer does not throw") {
+            shouldNotThrowAny {
+                programClassPool.classesAccept(ClassReferenceFixer(false))
             }
         }
     }

--- a/docs/md/releasenotes.md
+++ b/docs/md/releasenotes.md
@@ -4,6 +4,7 @@
 
 - Fix reference initialization for type aliases defined in file facades with a custom JvmPackageName.
 - Fix PKCS7OutputStream incorrectly handling escaped quotes certificates.
+- Fix `NullPointerException` in `ClassReferenceFixer` for Kotlin coroutine suspend lambdas by resolving their `referencedMethod` to `invokeSuspend`.
 
 ### Kotlin support
 


### PR DESCRIPTION
## Summary

`ClassReferenceInitializer.visitAnyFunction` never resolved the `referencedMethod` for coroutine suspend lambdas, leaving it null. `ClassReferenceFixer.visitAnyFunction` then dereferenced it and threw a `NullPointerException` on any class containing a suspend lambda (e.g. a `launch { }` body), even with a complete classpath.

Fixes #175.

## Root cause

A suspend lambda compiles to a `kotlin/coroutines/jvm/internal/SuspendLambda` subclass whose body lives in `invokeSuspend(Object)Object`, not `invoke`. Its Kotlin metadata records an `<anonymous>` `jvmSignature` carrying the *Kotlin-level* descriptor (e.g. `()V`), so the existing `<anonymous>` to `invoke` mapping (the T16483 workaround) looks up `findMethod("invoke", "()V")`, which the `SuspendLambda` subclass has no method for, and resolution silently returns null.

This is the same crash site as #174, but a different root cause: the reference doesn't resolve, rather than a class being absent from the pool. So it bites even when the classpath is complete, and #174's null guard alone would leave the suspend lambda's method reference unresolved (unfixed during renaming) rather than crashing. This change actually resolves it.

## Fix

When the `<anonymous>` to `invoke` lookup returns null, fall back to the fixed `invokeSuspend(Object)Object` signature. This is safe and self-guarding:

- Only `SuspendLambda` subclasses declare `invokeSuspend(Object)Object`, so the fallback cannot mismatch a plain (non-suspend) lambda: `findMethod` simply returns null and the reference stays unresolved, exactly as before.
- It runs only when the primary `invoke` lookup already failed, so it never changes a case that resolves today.
- It keys off the fixed `invokeSuspend` signature, not the metadata descriptor, so it is arity-independent.

## Tests

A new `ClassReferenceFixerTest` context compiles a suspend lambda and asserts:

- the anonymous function metadata now resolves to `invokeSuspend` (root cause)
- applying `ClassReferenceFixer` no longer throws (reported symptom)

Both were verified to fail before the fix (null resolution / NPE) and pass after. The fix was additionally probed against multi-arg, capturing, nested, value-returning, generic, and init-block suspend lambdas: every shape resolves to `invokeSuspend(Object)Object` on the correct class, and no non-suspend lambda is affected. The full `:proguard-core` suite in the touched packages still passes.
