### PR TITLE
Fix KotlinMetadataAsserter false positive on top-level callable references

### DIFF
--- a/base/src/main/java/proguard/util/kotlin/asserter/constraint/SyntheticClassIntegrity.java
+++ b/base/src/main/java/proguard/util/kotlin/asserter/constraint/SyntheticClassIntegrity.java
@@ -18,8 +18,6 @@
 package proguard.util.kotlin.asserter.constraint;
 
 import static proguard.classfile.kotlin.KotlinConstants.DEFAULT_IMPLEMENTATIONS_SUFFIX;
-import static proguard.classfile.kotlin.KotlinConstants.METADATA_KIND_FILE_FACADE;
-import static proguard.classfile.kotlin.KotlinConstants.METADATA_KIND_MULTI_FILE_CLASS_PART;
 import static proguard.classfile.kotlin.KotlinConstants.REFLECTION;
 import static proguard.classfile.kotlin.KotlinConstants.WHEN_MAPPINGS_SUFFIX;
 
@@ -109,17 +107,7 @@ public class SyntheticClassIntegrity extends AbstractKotlinMetadataConstraint
 
             private void checkOwner(CallableReferenceInfo callableReferenceInfo) {
               // We don't check this for JavaReferenceInfo.
-
               util.reportIfNull("owner", callableReferenceInfo.getOwner());
-              if (callableReferenceInfo.getOwner() != null) {
-                // We need the module to update the getOwner() method for file facades and
-                // multi-file class parts.
-                if (callableReferenceInfo.getOwner().k == METADATA_KIND_FILE_FACADE
-                    || callableReferenceInfo.getOwner().k == METADATA_KIND_MULTI_FILE_CLASS_PART) {
-                  util.reportIfNull(
-                      "referenced module", callableReferenceInfo.getOwner().referencedModule);
-                }
-              }
             }
           });
     }

--- a/base/src/test/kotlin/proguard/util/kotlin/asserter/KotlinMetadataAsserterTest.kt
+++ b/base/src/test/kotlin/proguard/util/kotlin/asserter/KotlinMetadataAsserterTest.kt
@@ -329,4 +329,26 @@ class KotlinMetadataAsserterTest : BehaviorSpec({
             facadeClass.kotlinMetadata shouldBe null
         }
     }
+
+    Given("a top-level function callable reference and no loaded .kotlin_module resource") {
+        val (programClassPool, libraryClassPool) = ClassPoolBuilder.fromSource(
+            KotlinSource(
+                "Test.kt",
+                """
+                fun foo() = "bar"
+                fun ref() = ::foo
+                """.trimIndent(),
+            ),
+        )
+
+        When("the KotlinMetadataAsserter is run") {
+            val referenceClass = programClassPool.getClass("TestKt\$ref\$1") as ProgramClass
+
+            Then("the callable reference metadata should not be thrown away") {
+                referenceClass.kotlinMetadata shouldNotBe null
+                KotlinMetadataAsserter().execute(warningLogger, programClassPool, libraryClassPool, ResourceFilePool())
+                referenceClass.kotlinMetadata shouldNotBe null
+            }
+        }
+    }
 })

--- a/docs/md/releasenotes.md
+++ b/docs/md/releasenotes.md
@@ -4,6 +4,7 @@
 
 - Fix reference initialization for type aliases defined in file facades with a custom JvmPackageName.
 - Fix PKCS7OutputStream incorrectly handling escaped quotes certificates.
+- Fix `KotlinMetadataAsserter` incorrectly discarding metadata for top-level function and property callable references when no `.kotlin_module` resource is loaded.
 
 ### Kotlin support
 


### PR DESCRIPTION
Fixes #178.

`SyntheticClassIntegrity.checkOwner()` required a non-null `referencedModule` on `FILE_FACADE` / `MULTI_FILE_CLASS_PART` owners. That field is populated only by `KotlinModuleReferenceInitializer`, which needs the caller to have first read a real `META-INF/*.kotlin_module` resource into a `ResourceFilePool`. A caller running `KotlinMetadataAsserter` as a general Kotlin-metadata sanity check, without wiring that resource, gets a spurious "has no referenced module" warning for every top-level function or property callable reference, and the reference's metadata is discarded.

This drops the `referencedModule` check, keeping the `owner` null-check (which `KotlinCallableReferenceInitializer` always populates). It matches the sibling constraints `FileFacadeIntegrity` and `MultiFilePartIntegrity`, which already omit the same check, and nothing on the owner path (`getOwner()`, `getName()`, `getSignature()`, `ownerAccept()`) reads `referencedModule`.

- Adds a regression test running the asserter on a freshly-compiled top-level function reference with an empty `ResourceFilePool`, asserting the callable-reference metadata survives.
- Adds a release-notes entry under 9.3.3.

Full `:proguard-core:test` suite passes (1063 tests, 4 skipped); `spotlessCheck` is clean.
